### PR TITLE
Fix homepage update and restructure modules

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -129,6 +129,80 @@
           "description": "Browse all demos, choose by interest"
         }
       }
+    },
+    "phase": "Phase",
+    "advanced": "Advanced",
+    "stage1": {
+      "title": "See Polarization",
+      "subtitle": "Discover the Third Property of Light",
+      "question": "What is polarization? Where can I see it?",
+      "demos": {
+        "intro": "What is Polarization?",
+        "types": "Polarization Types",
+        "bench": "Optical Bench"
+      },
+      "games": {
+        "level0": "Tutorial Level",
+        "level1": "Basic Practice"
+      }
+    },
+    "stage2": {
+      "title": "Understand the Rules",
+      "subtitle": "Master Polarization Physics",
+      "question": "What rules does polarized light follow?",
+      "demos": {
+        "malus": "Malus's Law",
+        "birefringence": "Birefringence",
+        "brewster": "Brewster's Angle",
+        "rayleigh": "Rayleigh Scattering",
+        "chromatic": "Chromatic Polarization"
+      },
+      "games": {
+        "level2": "Malus's Law Puzzle",
+        "level16": "Birefringence Maze"
+      },
+      "tools": {
+        "opticalStudio": "Optical Studio"
+      }
+    },
+    "stage3": {
+      "title": "Measure & Apply",
+      "subtitle": "Full Characterization & Frontier Tech",
+      "question": "How to precisely describe and utilize polarization?",
+      "demos": {
+        "stokes": "Stokes Vector",
+        "mueller": "Mueller Matrix",
+        "jones": "Jones Matrix",
+        "microscopy": "Polarimetric Microscopy"
+      },
+      "tools": {
+        "stokes": "Stokes Calculator",
+        "poincare": "Poincare Sphere",
+        "mueller": "Mueller Calculator"
+      }
+    },
+    "resources": {
+      "demos": "Interactive Demos",
+      "games": "Practice Games",
+      "tools": "Calculation Tools"
+    },
+    "startStage": "Start This Stage",
+    "startLearning": "Start Learning",
+    "explore": "Explore Freely",
+    "learningJourney": "Learning Journey",
+    "quickAccess": "Quick Access",
+    "quick": {
+      "games": "Games",
+      "demos": "Demos",
+      "calc": "Calc",
+      "experiments": "Experiments",
+      "chronicles": "Chronicles",
+      "lab": "Lab"
+    },
+    "stats": {
+      "completed": "Progress",
+      "streak": "Streak",
+      "time": "Time"
     }
   },
   "course": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -129,6 +129,80 @@
           "description": "浏览所有演示，按兴趣选择"
         }
       }
+    },
+    "phase": "阶段",
+    "advanced": "进阶",
+    "stage1": {
+      "title": "看见偏振",
+      "subtitle": "认识光的第三属性",
+      "question": "偏振是什么？我能在哪里看到它？",
+      "demos": {
+        "intro": "什么是偏振？",
+        "types": "偏振类型",
+        "bench": "光学工作台"
+      },
+      "games": {
+        "level0": "入门关卡",
+        "level1": "基础练习"
+      }
+    },
+    "stage2": {
+      "title": "理解规律",
+      "subtitle": "掌握偏振物理",
+      "question": "偏振光遵循什么规律？",
+      "demos": {
+        "malus": "马吕斯定律",
+        "birefringence": "双折射",
+        "brewster": "布儒斯特角",
+        "rayleigh": "瑞利散射",
+        "chromatic": "色偏振"
+      },
+      "games": {
+        "level2": "马吕斯定律谜题",
+        "level16": "双折射迷宫"
+      },
+      "tools": {
+        "opticalStudio": "光学设计室"
+      }
+    },
+    "stage3": {
+      "title": "测量与应用",
+      "subtitle": "完整表征与前沿技术",
+      "question": "如何精确描述和利用偏振？",
+      "demos": {
+        "stokes": "Stokes矢量",
+        "mueller": "Mueller矩阵",
+        "jones": "Jones矩阵",
+        "microscopy": "偏振显微镜"
+      },
+      "tools": {
+        "stokes": "Stokes计算器",
+        "poincare": "庞加莱球",
+        "mueller": "Mueller计算器"
+      }
+    },
+    "resources": {
+      "demos": "互动演示",
+      "games": "练习游戏",
+      "tools": "计算工具"
+    },
+    "startStage": "开始学习本阶段",
+    "startLearning": "开始学习",
+    "explore": "自由探索",
+    "learningJourney": "学习路径",
+    "quickAccess": "快捷入口",
+    "quick": {
+      "games": "游戏",
+      "demos": "演示",
+      "calc": "计算",
+      "experiments": "实验",
+      "chronicles": "编年史",
+      "lab": "实验室"
+    },
+    "stats": {
+      "completed": "进度",
+      "streak": "连续",
+      "time": "时长"
     }
   },
   "course": {


### PR DESCRIPTION
- Replace 6-module grid layout with PSRT 3-stage learning journey
- Stage 1: See Polarization (intro demos + beginner games)
- Stage 2: Understand Rules (physics demos + intermediate games + tools)
- Stage 3: Measure & Apply (advanced demos + calculation tools)
- Integrate demos, games, and tools as learning resources within each stage
- Add quick access menu for direct module navigation
- Show learning progress tracking (completed demos, streak, time)
- Update translations for new homepage content (en/zh)

Architecture change: Homepage = PSRT Course (3 modules as learning resources)