### PR TITLE
Redesign polarization demo with progressive content

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,9 @@ const LearningHubPage = lazy(() => import('@/pages/LearningHubPage'))
 const ExplorePage = lazy(() => import('@/pages/ExplorePage'))
 const ExplorationNodePage = lazy(() => import('@/pages/ExplorationNodePage'))
 
+// Discovery Page - 渐进式探索入口 (Google Learn About inspired)
+const DiscoveryPage = lazy(() => import('@/pages/DiscoveryPage'))
+
 // Course Content Layer - 《偏振光下的世界》独立课程
 const WorldCourseHome = lazy(() => import('@/course/pages/CourseHome'))
 const WorldCourseUnit = lazy(() => import('@/course/pages/UnitOverview'))
@@ -82,6 +85,10 @@ export function App() {
         {/* Exploration - 问题驱动的探索系统 */}
         <Route path="/explore" element={<ExplorePage />} />
         <Route path="/explore/:nodeId" element={<ExplorationNodePage />} />
+
+        {/* Discovery - 渐进式探索入口 (避免信息过载的新设计) */}
+        <Route path="/discover" element={<DiscoveryPage />} />
+        <Route path="/discover/:topicId" element={<DiscoveryPage />} />
 
         {/* Optical Design Studio - 光学设计室 (模块化版本) */}
         <Route path="/optical-studio" element={<OpticalDesignPage />} />

--- a/src/components/discovery/GuidedExplorationPath.tsx
+++ b/src/components/discovery/GuidedExplorationPath.tsx
@@ -1,0 +1,716 @@
+/**
+ * GuidedExplorationPath - 引导式探索路径
+ *
+ * 设计理念：
+ * - 线性叙事结构，但允许跳跃
+ * - 每个节点只展示最核心的内容
+ * - 渐进式深度 - 基础 → 应用 → 研究
+ * - 多入口多出口的网状连接
+ */
+
+import { useState, useMemo } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/contexts/ThemeContext'
+import { cn } from '@/lib/utils'
+import { motion, AnimatePresence } from 'framer-motion'
+import {
+  ChevronRight,
+  ChevronLeft,
+  Check,
+  Lock,
+  Play,
+  Gamepad2,
+  FlaskConical,
+  BookOpen,
+  Lightbulb,
+  ArrowRight,
+  Star,
+  Sparkles
+} from 'lucide-react'
+
+// 路径节点类型
+export interface PathNode {
+  id: string
+  title: { en: string; zh: string }
+  description: { en: string; zh: string }
+  type: 'concept' | 'demo' | 'experiment' | 'game' | 'checkpoint'
+  // 内容（根据类型不同）
+  demoId?: string
+  gameRoute?: string
+  experimentId?: string
+  // 核心要点（最多3个）
+  keyPoints?: { en: string; zh: string }[]
+  // Stop & Think 问题
+  thinkQuestion?: { en: string; zh: string }
+  // 时间估计（分钟）
+  duration?: number
+  // 是否可选
+  optional?: boolean
+}
+
+// 探索路径定义
+export interface ExplorationPath {
+  id: string
+  title: { en: string; zh: string }
+  description: { en: string; zh: string }
+  targetAudience: { en: string; zh: string }
+  estimatedTime: number // 分钟
+  difficulty: 'beginner' | 'intermediate' | 'advanced'
+  color: string
+  nodes: PathNode[]
+  prerequisites?: string[]
+  rewards?: { en: string; zh: string }[]
+}
+
+// 节点类型配置
+const NODE_TYPE_CONFIG = {
+  concept: {
+    icon: <BookOpen className="w-4 h-4" />,
+    color: '#22d3ee',
+    labelEn: 'Learn',
+    labelZh: '学习'
+  },
+  demo: {
+    icon: <Play className="w-4 h-4" />,
+    color: '#10b981',
+    labelEn: 'Explore',
+    labelZh: '探索'
+  },
+  experiment: {
+    icon: <FlaskConical className="w-4 h-4" />,
+    color: '#f59e0b',
+    labelEn: 'Try',
+    labelZh: '尝试'
+  },
+  game: {
+    icon: <Gamepad2 className="w-4 h-4" />,
+    color: '#ec4899',
+    labelEn: 'Play',
+    labelZh: '游戏'
+  },
+  checkpoint: {
+    icon: <Lightbulb className="w-4 h-4" />,
+    color: '#8b5cf6',
+    labelEn: 'Reflect',
+    labelZh: '反思'
+  }
+}
+
+// 预定义的探索路径
+export const EXPLORATION_PATHS: ExplorationPath[] = [
+  {
+    id: 'polarization-basics',
+    title: {
+      en: 'Polarization Basics',
+      zh: '偏振基础'
+    },
+    description: {
+      en: 'Discover what polarization is and why it matters',
+      zh: '发现什么是偏振以及它为什么重要'
+    },
+    targetAudience: {
+      en: 'Anyone curious about light',
+      zh: '对光感到好奇的任何人'
+    },
+    estimatedTime: 15,
+    difficulty: 'beginner',
+    color: '#22c55e',
+    nodes: [
+      {
+        id: 'intro',
+        title: { en: 'What is Polarization?', zh: '什么是偏振？' },
+        description: {
+          en: 'Light as a wave that can vibrate in different directions',
+          zh: '光是一种可以在不同方向振动的波'
+        },
+        type: 'concept',
+        keyPoints: [
+          { en: 'Light is a wave', zh: '光是一种波' },
+          { en: 'Waves can vibrate in different directions', zh: '波可以在不同方向振动' },
+          { en: 'Polarization describes the vibration direction', zh: '偏振描述振动方向' }
+        ],
+        duration: 3
+      },
+      {
+        id: 'demo-intro',
+        title: { en: 'See Polarization', zh: '看见偏振' },
+        description: {
+          en: 'Interactive visualization of polarized light',
+          zh: '偏振光的互动可视化'
+        },
+        type: 'demo',
+        demoId: 'polarization-intro',
+        duration: 3
+      },
+      {
+        id: 'checkpoint-1',
+        title: { en: 'Stop & Think', zh: '停下来想想' },
+        description: {
+          en: 'Reflect on what you\'ve learned',
+          zh: '反思你学到的东西'
+        },
+        type: 'checkpoint',
+        thinkQuestion: {
+          en: 'If light can vibrate in any direction, what makes "polarized" light special?',
+          zh: '如果光可以向任何方向振动，"偏振"光有什么特别之处？'
+        },
+        duration: 2
+      },
+      {
+        id: 'experiment-sunglasses',
+        title: { en: 'Try It Yourself', zh: '亲自尝试' },
+        description: {
+          en: 'Discover polarization with sunglasses',
+          zh: '用太阳镜发现偏振'
+        },
+        type: 'experiment',
+        experimentId: 'polarizer-sunglasses',
+        duration: 5
+      },
+      {
+        id: 'game-level1',
+        title: { en: 'Test Your Knowledge', zh: '测试你的知识' },
+        description: {
+          en: 'Solve a simple polarization puzzle',
+          zh: '解决一个简单的偏振谜题'
+        },
+        type: 'game',
+        gameRoute: '/games/2d?level=0',
+        optional: true,
+        duration: 3
+      }
+    ],
+    rewards: [
+      { en: 'Understand polarization basics', zh: '理解偏振基础' },
+      { en: 'Know why polarized sunglasses work', zh: '知道偏振太阳镜为什么有效' }
+    ]
+  },
+  {
+    id: 'malus-law-journey',
+    title: {
+      en: "Malus's Law Adventure",
+      zh: '马吕斯定律之旅'
+    },
+    description: {
+      en: 'Discover the mathematics behind polarizers',
+      zh: '发现偏振片背后的数学'
+    },
+    targetAudience: {
+      en: 'Learners ready for formulas',
+      zh: '准备好学习公式的学习者'
+    },
+    estimatedTime: 20,
+    difficulty: 'intermediate',
+    color: '#f59e0b',
+    prerequisites: ['polarization-basics'],
+    nodes: [
+      {
+        id: 'setup',
+        title: { en: 'The Question', zh: '问题' },
+        description: {
+          en: 'How much light passes through a polarizer?',
+          zh: '有多少光能通过偏振片？'
+        },
+        type: 'concept',
+        keyPoints: [
+          { en: 'Polarizers filter light', zh: '偏振片过滤光' },
+          { en: 'The amount depends on the angle', zh: '通过量取决于角度' }
+        ],
+        duration: 2
+      },
+      {
+        id: 'demo-malus',
+        title: { en: 'See the Pattern', zh: '看到规律' },
+        description: {
+          en: 'Watch intensity change with angle',
+          zh: '观察强度随角度变化'
+        },
+        type: 'demo',
+        demoId: 'malus',
+        duration: 5
+      },
+      {
+        id: 'reveal',
+        title: { en: 'The Formula', zh: '公式' },
+        description: {
+          en: 'I = I₀ cos²(θ) - the intensity follows cosine squared!',
+          zh: 'I = I₀ cos²(θ) - 强度遵循余弦平方！'
+        },
+        type: 'concept',
+        keyPoints: [
+          { en: 'I = transmitted intensity', zh: 'I = 透射强度' },
+          { en: 'I₀ = initial intensity', zh: 'I₀ = 初始强度' },
+          { en: 'θ = angle between polarization and filter', zh: 'θ = 偏振方向与滤光片的夹角' }
+        ],
+        duration: 3
+      },
+      {
+        id: 'checkpoint-2',
+        title: { en: 'Predict', zh: '预测' },
+        description: {
+          en: 'What happens at 45°? At 90°?',
+          zh: '在45°时会发生什么？在90°时呢？'
+        },
+        type: 'checkpoint',
+        thinkQuestion: {
+          en: 'At 45°, is half the light transmitted? More? Less?',
+          zh: '在45°时，是一半的光透过吗？更多？更少？'
+        },
+        duration: 2
+      },
+      {
+        id: 'game-malus',
+        title: { en: 'Apply It', zh: '应用它' },
+        description: {
+          en: 'Use your new knowledge to solve puzzles',
+          zh: '用你的新知识解决谜题'
+        },
+        type: 'game',
+        gameRoute: '/games/2d?level=2',
+        duration: 5
+      }
+    ],
+    rewards: [
+      { en: 'Understand Malus\'s Law', zh: '理解马吕斯定律' },
+      { en: 'Predict polarizer behavior', zh: '预测偏振片行为' },
+      { en: 'Use the cos² formula', zh: '使用cos²公式' }
+    ]
+  }
+]
+
+interface GuidedExplorationPathProps {
+  path: ExplorationPath
+  onComplete?: () => void
+  startNode?: number
+}
+
+export function GuidedExplorationPath({
+  path,
+  onComplete,
+  startNode = 0
+}: GuidedExplorationPathProps) {
+  const { theme } = useTheme()
+  const { i18n } = useTranslation()
+  const isZh = i18n.language === 'zh'
+  const navigate = useNavigate()
+
+  const [currentNodeIndex, setCurrentNodeIndex] = useState(startNode)
+  const [completedNodes, setCompletedNodes] = useState<string[]>([])
+  const [isStarted, setIsStarted] = useState(false)
+
+  const currentNode = path.nodes[currentNodeIndex]
+  const nodeConfig = NODE_TYPE_CONFIG[currentNode?.type || 'concept']
+  const progress = (completedNodes.length / path.nodes.length) * 100
+
+  // 标记节点完成
+  const completeCurrentNode = () => {
+    if (!completedNodes.includes(currentNode.id)) {
+      setCompletedNodes(prev => [...prev, currentNode.id])
+    }
+  }
+
+  // 前进到下一节点
+  const goToNextNode = () => {
+    completeCurrentNode()
+    if (currentNodeIndex < path.nodes.length - 1) {
+      setCurrentNodeIndex(prev => prev + 1)
+    } else {
+      onComplete?.()
+    }
+  }
+
+  // 返回上一节点
+  const goToPrevNode = () => {
+    if (currentNodeIndex > 0) {
+      setCurrentNodeIndex(prev => prev - 1)
+    }
+  }
+
+  // 跳转到特定节点
+  const jumpToNode = (index: number) => {
+    setCurrentNodeIndex(index)
+  }
+
+  // 处理节点动作
+  const handleNodeAction = () => {
+    switch (currentNode.type) {
+      case 'demo':
+        if (currentNode.demoId) {
+          navigate(`/demos/${currentNode.demoId}`)
+        }
+        break
+      case 'game':
+        if (currentNode.gameRoute) {
+          navigate(currentNode.gameRoute)
+        }
+        break
+      case 'experiment':
+        // 在当前页面展示实验模块
+        break
+      default:
+        goToNextNode()
+    }
+  }
+
+  if (!isStarted) {
+    // 路径介绍页
+    return (
+      <div className={cn(
+        'rounded-2xl overflow-hidden',
+        theme === 'dark' ? 'bg-slate-800' : 'bg-white shadow-lg'
+      )}>
+        <div
+          className="h-2"
+          style={{ backgroundColor: path.color }}
+        />
+        <div className="p-6 space-y-5">
+          {/* 标题 */}
+          <div>
+            <span
+              className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium text-white mb-3"
+              style={{ backgroundColor: path.color }}
+            >
+              <Sparkles className="w-3 h-3" />
+              {path.difficulty === 'beginner'
+                ? (isZh ? '入门' : 'Beginner')
+                : path.difficulty === 'intermediate'
+                  ? (isZh ? '进阶' : 'Intermediate')
+                  : (isZh ? '高级' : 'Advanced')}
+            </span>
+            <h2 className={cn(
+              'text-xl font-bold mb-2',
+              theme === 'dark' ? 'text-white' : 'text-gray-900'
+            )}>
+              {isZh ? path.title.zh : path.title.en}
+            </h2>
+            <p className={cn(
+              'text-sm',
+              theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
+            )}>
+              {isZh ? path.description.zh : path.description.en}
+            </p>
+          </div>
+
+          {/* 元信息 */}
+          <div className="flex items-center gap-4 text-sm">
+            <span className={cn(
+              theme === 'dark' ? 'text-gray-500' : 'text-gray-400'
+            )}>
+              ⏱️ ~{path.estimatedTime} {isZh ? '分钟' : 'min'}
+            </span>
+            <span className={cn(
+              theme === 'dark' ? 'text-gray-500' : 'text-gray-400'
+            )}>
+              📍 {path.nodes.length} {isZh ? '个站点' : 'stops'}
+            </span>
+          </div>
+
+          {/* 路线预览 */}
+          <div className={cn(
+            'p-4 rounded-xl',
+            theme === 'dark' ? 'bg-slate-700/50' : 'bg-gray-50'
+          )}>
+            <h3 className={cn(
+              'text-sm font-medium mb-3',
+              theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+            )}>
+              {isZh ? '路线预览' : 'Path Preview'}
+            </h3>
+            <div className="space-y-2">
+              {path.nodes.slice(0, 4).map((node, idx) => {
+                const config = NODE_TYPE_CONFIG[node.type]
+                return (
+                  <div
+                    key={node.id}
+                    className="flex items-center gap-3"
+                  >
+                    <div
+                      className="w-6 h-6 rounded-full flex items-center justify-center text-white text-xs"
+                      style={{ backgroundColor: config.color }}
+                    >
+                      {idx + 1}
+                    </div>
+                    <span className={cn(
+                      'text-sm',
+                      theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+                    )}>
+                      {isZh ? node.title.zh : node.title.en}
+                    </span>
+                    {node.optional && (
+                      <span className={cn(
+                        'text-xs px-1.5 py-0.5 rounded',
+                        theme === 'dark' ? 'bg-slate-600 text-gray-400' : 'bg-gray-200 text-gray-500'
+                      )}>
+                        {isZh ? '可选' : 'Optional'}
+                      </span>
+                    )}
+                  </div>
+                )
+              })}
+              {path.nodes.length > 4 && (
+                <span className={cn(
+                  'text-xs',
+                  theme === 'dark' ? 'text-gray-500' : 'text-gray-400'
+                )}>
+                  +{path.nodes.length - 4} {isZh ? '更多' : 'more'}...
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* 你将学会 */}
+          {path.rewards && (
+            <div>
+              <h3 className={cn(
+                'text-sm font-medium mb-2',
+                theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+              )}>
+                {isZh ? '你将学会' : 'You will learn'}
+              </h3>
+              <ul className="space-y-1">
+                {path.rewards.map((reward, idx) => (
+                  <li
+                    key={idx}
+                    className="flex items-center gap-2 text-sm"
+                  >
+                    <Star className="w-3 h-3 text-amber-500" />
+                    <span className={cn(
+                      theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
+                    )}>
+                      {isZh ? reward.zh : reward.en}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* 开始按钮 */}
+          <button
+            onClick={() => setIsStarted(true)}
+            className="w-full py-3 rounded-xl text-white font-medium hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+            style={{ backgroundColor: path.color }}
+          >
+            {isZh ? '开始探索' : 'Start Journey'}
+            <ArrowRight className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  // 探索进行中
+  return (
+    <div className={cn(
+      'rounded-2xl overflow-hidden',
+      theme === 'dark' ? 'bg-slate-800' : 'bg-white shadow-lg'
+    )}>
+      {/* 进度条 */}
+      <div className={cn(
+        'h-1',
+        theme === 'dark' ? 'bg-slate-700' : 'bg-gray-100'
+      )}>
+        <motion.div
+          className="h-full"
+          style={{ backgroundColor: path.color }}
+          initial={{ width: 0 }}
+          animate={{ width: `${progress}%` }}
+        />
+      </div>
+
+      {/* 节点导航 */}
+      <div className={cn(
+        'px-4 py-3 flex items-center gap-1 overflow-x-auto',
+        theme === 'dark' ? 'bg-slate-700/30' : 'bg-gray-50'
+      )}>
+        {path.nodes.map((node, idx) => {
+          const config = NODE_TYPE_CONFIG[node.type]
+          const isCompleted = completedNodes.includes(node.id)
+          const isCurrent = idx === currentNodeIndex
+
+          return (
+            <button
+              key={node.id}
+              onClick={() => jumpToNode(idx)}
+              className={cn(
+                'flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center transition-all',
+                isCurrent && 'ring-2 ring-offset-2',
+                isCompleted
+                  ? 'bg-green-500 text-white'
+                  : isCurrent
+                    ? 'text-white'
+                    : theme === 'dark'
+                      ? 'bg-slate-600 text-gray-400'
+                      : 'bg-gray-200 text-gray-500'
+              )}
+              style={{
+                backgroundColor: isCurrent && !isCompleted ? config.color : undefined,
+                // @ts-ignore
+                '--tw-ring-color': config.color
+              }}
+            >
+              {isCompleted ? (
+                <Check className="w-4 h-4" />
+              ) : (
+                <span className="text-xs font-medium">{idx + 1}</span>
+              )}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* 当前节点内容 */}
+      <div className="p-6">
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={currentNode.id}
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -20 }}
+            className="space-y-5"
+          >
+            {/* 节点标题 */}
+            <div className="flex items-start gap-3">
+              <div
+                className="w-10 h-10 rounded-full flex items-center justify-center text-white flex-shrink-0"
+                style={{ backgroundColor: nodeConfig.color }}
+              >
+                {nodeConfig.icon}
+              </div>
+              <div>
+                <span
+                  className="text-xs font-medium uppercase tracking-wider"
+                  style={{ color: nodeConfig.color }}
+                >
+                  {isZh ? nodeConfig.labelZh : nodeConfig.labelEn}
+                </span>
+                <h3 className={cn(
+                  'font-semibold',
+                  theme === 'dark' ? 'text-white' : 'text-gray-900'
+                )}>
+                  {isZh ? currentNode.title.zh : currentNode.title.en}
+                </h3>
+              </div>
+            </div>
+
+            {/* 描述 */}
+            <p className={cn(
+              'text-sm leading-relaxed',
+              theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+            )}>
+              {isZh ? currentNode.description.zh : currentNode.description.en}
+            </p>
+
+            {/* 关键要点 */}
+            {currentNode.keyPoints && (
+              <div className={cn(
+                'p-4 rounded-xl space-y-2',
+                theme === 'dark' ? 'bg-slate-700/50' : 'bg-gray-50'
+              )}>
+                {currentNode.keyPoints.map((point, idx) => (
+                  <div
+                    key={idx}
+                    className="flex items-start gap-2"
+                  >
+                    <span style={{ color: nodeConfig.color }}>•</span>
+                    <span className={cn(
+                      'text-sm',
+                      theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+                    )}>
+                      {isZh ? point.zh : point.en}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* 思考问题 */}
+            {currentNode.thinkQuestion && (
+              <div className={cn(
+                'p-4 rounded-xl border-l-4',
+                theme === 'dark' ? 'bg-purple-500/10' : 'bg-purple-50'
+              )} style={{ borderColor: '#8b5cf6' }}>
+                <div className="flex items-start gap-2">
+                  <Lightbulb className="w-4 h-4 text-purple-500 flex-shrink-0 mt-0.5" />
+                  <p className={cn(
+                    'text-sm',
+                    theme === 'dark' ? 'text-purple-300' : 'text-purple-800'
+                  )}>
+                    {isZh ? currentNode.thinkQuestion.zh : currentNode.thinkQuestion.en}
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {/* 动作按钮 */}
+            {(currentNode.type === 'demo' || currentNode.type === 'game') && (
+              <button
+                onClick={handleNodeAction}
+                className="w-full py-3 rounded-xl text-white font-medium hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+                style={{ backgroundColor: nodeConfig.color }}
+              >
+                {currentNode.type === 'demo' && (
+                  <>
+                    <Play className="w-4 h-4" />
+                    {isZh ? '打开演示' : 'Open Demo'}
+                  </>
+                )}
+                {currentNode.type === 'game' && (
+                  <>
+                    <Gamepad2 className="w-4 h-4" />
+                    {isZh ? '开始游戏' : 'Play Game'}
+                  </>
+                )}
+              </button>
+            )}
+
+            {/* 导航 */}
+            <div className="flex items-center justify-between pt-4">
+              <button
+                onClick={goToPrevNode}
+                disabled={currentNodeIndex === 0}
+                className={cn(
+                  'flex items-center gap-1 px-4 py-2 rounded-lg text-sm transition-colors',
+                  currentNodeIndex === 0
+                    ? 'opacity-50 cursor-not-allowed'
+                    : '',
+                  theme === 'dark'
+                    ? 'text-gray-400 hover:text-white hover:bg-slate-700'
+                    : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                )}
+              >
+                <ChevronLeft className="w-4 h-4" />
+                {isZh ? '上一步' : 'Back'}
+              </button>
+
+              <span className={cn(
+                'text-xs',
+                theme === 'dark' ? 'text-gray-500' : 'text-gray-400'
+              )}>
+                {currentNodeIndex + 1} / {path.nodes.length}
+              </span>
+
+              <button
+                onClick={goToNextNode}
+                className={cn(
+                  'flex items-center gap-1 px-4 py-2 rounded-lg text-sm font-medium transition-colors text-white',
+                )}
+                style={{ backgroundColor: path.color }}
+              >
+                {currentNodeIndex === path.nodes.length - 1
+                  ? (isZh ? '完成' : 'Finish')
+                  : currentNode.optional
+                    ? (isZh ? '跳过' : 'Skip')
+                    : (isZh ? '继续' : 'Continue')}
+                <ChevronRight className="w-4 h-4" />
+              </button>
+            </div>
+          </motion.div>
+        </AnimatePresence>
+      </div>
+    </div>
+  )
+}
+
+export default GuidedExplorationPath

--- a/src/components/discovery/InteractiveExperimentModule.tsx
+++ b/src/components/discovery/InteractiveExperimentModule.tsx
@@ -1,0 +1,686 @@
+/**
+ * InteractiveExperimentModule - 互动实验模块
+ *
+ * 设计理念：
+ * - 叙事驱动 - 用故事串联实验步骤
+ * - 渐进披露 - 一次只展示一个步骤
+ * - 预测优先 - 先让用户猜测，再揭示结果
+ * - 反思整合 - 实验后引导思考
+ */
+
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/contexts/ThemeContext'
+import { cn } from '@/lib/utils'
+import { motion, AnimatePresence } from 'framer-motion'
+import {
+  ChevronRight,
+  ChevronLeft,
+  Play,
+  Check,
+  AlertTriangle,
+  Lightbulb,
+  Eye,
+  RefreshCw,
+  ExternalLink,
+  Package
+} from 'lucide-react'
+
+// 实验步骤类型
+interface ExperimentStep {
+  id: string
+  type: 'setup' | 'action' | 'observe' | 'predict' | 'reveal' | 'reflect'
+  title: { en: string; zh: string }
+  instruction: { en: string; zh: string }
+  image?: string
+  prediction?: {
+    question: { en: string; zh: string }
+    options?: { en: string; zh: string }[]
+    correctAnswer?: number
+  }
+  observation?: { en: string; zh: string }
+  reflection?: { en: string; zh: string }
+  tip?: { en: string; zh: string }
+}
+
+// 实验定义
+export interface Experiment {
+  id: string
+  title: { en: string; zh: string }
+  hook: { en: string; zh: string }  // 引人入胜的问题
+  difficulty: 'easy' | 'medium' | 'advanced'
+  duration: number  // 分钟
+  materials: {
+    name: { en: string; zh: string }
+    note?: { en: string; zh: string }
+    alternative?: { en: string; zh: string }
+    icon?: string
+  }[]
+  safetyNote?: { en: string; zh: string }
+  steps: ExperimentStep[]
+  conclusion: { en: string; zh: string }
+  nextSteps?: {
+    type: 'demo' | 'game' | 'experiment' | 'calculator'
+    id: string
+    label: { en: string; zh: string }
+  }[]
+  relatedConcepts?: string[]
+}
+
+// 难度标签配置
+const DIFFICULTY_CONFIG = {
+  easy: { labelEn: 'Beginner', labelZh: '入门', color: '#22c55e', icon: '🌱' },
+  medium: { labelEn: 'Intermediate', labelZh: '进阶', color: '#f59e0b', icon: '🔬' },
+  advanced: { labelEn: 'Advanced', labelZh: '高级', color: '#ef4444', icon: '🚀' }
+}
+
+// 步骤类型配置
+const STEP_TYPE_CONFIG = {
+  setup: { labelEn: 'Setup', labelZh: '准备', icon: <Package className="w-4 h-4" /> },
+  action: { labelEn: 'Do This', labelZh: '操作', icon: <Play className="w-4 h-4" /> },
+  observe: { labelEn: 'Observe', labelZh: '观察', icon: <Eye className="w-4 h-4" /> },
+  predict: { labelEn: 'Predict', labelZh: '预测', icon: <Lightbulb className="w-4 h-4" /> },
+  reveal: { labelEn: 'Result', labelZh: '结果', icon: <Check className="w-4 h-4" /> },
+  reflect: { labelEn: 'Think', labelZh: '思考', icon: <Lightbulb className="w-4 h-4" /> }
+}
+
+interface InteractiveExperimentModuleProps {
+  experiment: Experiment
+  onComplete?: () => void
+}
+
+export function InteractiveExperimentModule({
+  experiment,
+  onComplete
+}: InteractiveExperimentModuleProps) {
+  const { theme } = useTheme()
+  const { i18n } = useTranslation()
+  const isZh = i18n.language === 'zh'
+
+  const [currentStep, setCurrentStep] = useState(-1)  // -1 = 介绍页
+  const [predictions, setPredictions] = useState<Record<string, number>>({})
+  const [showMaterials, setShowMaterials] = useState(false)
+  const [isCompleted, setIsCompleted] = useState(false)
+
+  const difficultyConfig = DIFFICULTY_CONFIG[experiment.difficulty]
+  const totalSteps = experiment.steps.length
+
+  // 处理预测选择
+  const handlePrediction = (stepId: string, optionIndex: number) => {
+    setPredictions(prev => ({ ...prev, [stepId]: optionIndex }))
+  }
+
+  // 前进到下一步
+  const goNext = () => {
+    if (currentStep < totalSteps - 1) {
+      setCurrentStep(prev => prev + 1)
+    } else {
+      setIsCompleted(true)
+      onComplete?.()
+    }
+  }
+
+  // 返回上一步
+  const goPrev = () => {
+    if (currentStep > -1) {
+      setCurrentStep(prev => prev - 1)
+    }
+  }
+
+  // 重置实验
+  const reset = () => {
+    setCurrentStep(-1)
+    setPredictions({})
+    setIsCompleted(false)
+  }
+
+  // 当前步骤数据
+  const step = currentStep >= 0 ? experiment.steps[currentStep] : null
+  const stepConfig = step ? STEP_TYPE_CONFIG[step.type] : null
+
+  return (
+    <div className={cn(
+      'rounded-2xl overflow-hidden',
+      theme === 'dark' ? 'bg-slate-800' : 'bg-white shadow-lg'
+    )}>
+      {/* 顶部进度条 */}
+      <div className={cn(
+        'h-1 transition-all',
+        theme === 'dark' ? 'bg-slate-700' : 'bg-gray-100'
+      )}>
+        <motion.div
+          className="h-full bg-gradient-to-r from-cyan-500 to-green-500"
+          initial={{ width: 0 }}
+          animate={{
+            width: `${((currentStep + 1) / totalSteps) * 100}%`
+          }}
+        />
+      </div>
+
+      {/* 主内容区 */}
+      <div className="p-6">
+        <AnimatePresence mode="wait">
+          {/* 介绍页 */}
+          {currentStep === -1 && !isCompleted && (
+            <motion.div
+              key="intro"
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -20 }}
+              className="space-y-5"
+            >
+              {/* 标题和难度 */}
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h2 className={cn(
+                    'text-xl font-bold mb-2',
+                    theme === 'dark' ? 'text-white' : 'text-gray-900'
+                  )}>
+                    {isZh ? experiment.title.zh : experiment.title.en}
+                  </h2>
+                  <p className={cn(
+                    'text-sm',
+                    theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
+                  )}>
+                    {isZh ? experiment.hook.zh : experiment.hook.en}
+                  </p>
+                </div>
+                <div className="flex flex-col items-end gap-2">
+                  <span
+                    className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium text-white"
+                    style={{ backgroundColor: difficultyConfig.color }}
+                  >
+                    {difficultyConfig.icon}
+                    {isZh ? difficultyConfig.labelZh : difficultyConfig.labelEn}
+                  </span>
+                  <span className={cn(
+                    'text-xs',
+                    theme === 'dark' ? 'text-gray-500' : 'text-gray-400'
+                  )}>
+                    ~{experiment.duration} {isZh ? '分钟' : 'min'}
+                  </span>
+                </div>
+              </div>
+
+              {/* 安全提示 */}
+              {experiment.safetyNote && (
+                <div className={cn(
+                  'p-3 rounded-lg flex items-start gap-2',
+                  theme === 'dark'
+                    ? 'bg-amber-500/10 border border-amber-500/20'
+                    : 'bg-amber-50 border border-amber-100'
+                )}>
+                  <AlertTriangle className="w-4 h-4 text-amber-500 flex-shrink-0 mt-0.5" />
+                  <p className={cn(
+                    'text-xs',
+                    theme === 'dark' ? 'text-amber-300' : 'text-amber-800'
+                  )}>
+                    {isZh ? experiment.safetyNote.zh : experiment.safetyNote.en}
+                  </p>
+                </div>
+              )}
+
+              {/* 材料清单 */}
+              <div>
+                <button
+                  onClick={() => setShowMaterials(!showMaterials)}
+                  className={cn(
+                    'w-full flex items-center justify-between p-3 rounded-lg transition-colors',
+                    theme === 'dark'
+                      ? 'bg-slate-700/50 hover:bg-slate-700'
+                      : 'bg-gray-50 hover:bg-gray-100'
+                  )}
+                >
+                  <span className={cn(
+                    'font-medium text-sm flex items-center gap-2',
+                    theme === 'dark' ? 'text-white' : 'text-gray-900'
+                  )}>
+                    <Package className="w-4 h-4" />
+                    {isZh ? '你需要准备' : 'You will need'}
+                    <span className={cn(
+                      'px-1.5 py-0.5 rounded text-xs',
+                      theme === 'dark' ? 'bg-slate-600' : 'bg-gray-200'
+                    )}>
+                      {experiment.materials.length}
+                    </span>
+                  </span>
+                  <ChevronRight
+                    className={cn(
+                      'w-4 h-4 transition-transform',
+                      showMaterials && 'rotate-90'
+                    )}
+                  />
+                </button>
+
+                <AnimatePresence>
+                  {showMaterials && (
+                    <motion.div
+                      initial={{ height: 0, opacity: 0 }}
+                      animate={{ height: 'auto', opacity: 1 }}
+                      exit={{ height: 0, opacity: 0 }}
+                      className="overflow-hidden"
+                    >
+                      <div className="pt-3 grid grid-cols-2 gap-2">
+                        {experiment.materials.map((material, idx) => (
+                          <div
+                            key={idx}
+                            className={cn(
+                              'p-2.5 rounded-lg',
+                              theme === 'dark' ? 'bg-slate-700/30' : 'bg-gray-50'
+                            )}
+                          >
+                            <div className="flex items-center gap-2 mb-1">
+                              <span className="text-lg">{material.icon || '📦'}</span>
+                              <span className={cn(
+                                'text-sm font-medium',
+                                theme === 'dark' ? 'text-white' : 'text-gray-900'
+                              )}>
+                                {isZh ? material.name.zh : material.name.en}
+                              </span>
+                            </div>
+                            {material.note && (
+                              <p className={cn(
+                                'text-xs',
+                                theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+                              )}>
+                                {isZh ? material.note.zh : material.note.en}
+                              </p>
+                            )}
+                            {material.alternative && (
+                              <p className="text-xs text-cyan-500 mt-1">
+                                {isZh ? '替代：' : 'Alt: '}
+                                {isZh ? material.alternative.zh : material.alternative.en}
+                              </p>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
+
+              {/* 开始按钮 */}
+              <button
+                onClick={goNext}
+                className="w-full py-3 rounded-xl bg-gradient-to-r from-cyan-500 to-green-500 text-white font-medium hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+              >
+                <Play className="w-4 h-4" />
+                {isZh ? '开始实验' : 'Start Experiment'}
+              </button>
+            </motion.div>
+          )}
+
+          {/* 实验步骤 */}
+          {step && !isCompleted && (
+            <motion.div
+              key={`step-${currentStep}`}
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -20 }}
+              className="space-y-5"
+            >
+              {/* 步骤标题 */}
+              <div className="flex items-center gap-3">
+                <div
+                  className="w-10 h-10 rounded-full flex items-center justify-center text-white"
+                  style={{
+                    backgroundColor: step.type === 'predict' ? '#f59e0b' :
+                                     step.type === 'reveal' ? '#22c55e' :
+                                     step.type === 'reflect' ? '#8b5cf6' :
+                                     '#06b6d4'
+                  }}
+                >
+                  {stepConfig?.icon}
+                </div>
+                <div>
+                  <span className={cn(
+                    'text-xs font-medium uppercase tracking-wider',
+                    theme === 'dark' ? 'text-gray-500' : 'text-gray-400'
+                  )}>
+                    {isZh
+                      ? `第 ${currentStep + 1} 步 / 共 ${totalSteps} 步`
+                      : `Step ${currentStep + 1} of ${totalSteps}`}
+                  </span>
+                  <h3 className={cn(
+                    'font-semibold',
+                    theme === 'dark' ? 'text-white' : 'text-gray-900'
+                  )}>
+                    {isZh ? step.title.zh : step.title.en}
+                  </h3>
+                </div>
+              </div>
+
+              {/* 步骤说明 */}
+              <p className={cn(
+                'text-sm leading-relaxed',
+                theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+              )}>
+                {isZh ? step.instruction.zh : step.instruction.en}
+              </p>
+
+              {/* 预测问题 */}
+              {step.type === 'predict' && step.prediction && (
+                <div className={cn(
+                  'p-4 rounded-xl',
+                  theme === 'dark' ? 'bg-amber-500/10' : 'bg-amber-50'
+                )}>
+                  <p className={cn(
+                    'font-medium mb-3',
+                    theme === 'dark' ? 'text-amber-300' : 'text-amber-800'
+                  )}>
+                    {isZh ? step.prediction.question.zh : step.prediction.question.en}
+                  </p>
+                  {step.prediction.options && (
+                    <div className="space-y-2">
+                      {step.prediction.options.map((option, idx) => (
+                        <button
+                          key={idx}
+                          onClick={() => handlePrediction(step.id, idx)}
+                          className={cn(
+                            'w-full text-left p-3 rounded-lg border-2 transition-all',
+                            predictions[step.id] === idx
+                              ? 'border-amber-500 bg-amber-500/20'
+                              : theme === 'dark'
+                                ? 'border-slate-600 hover:border-slate-500'
+                                : 'border-gray-200 hover:border-gray-300'
+                          )}
+                        >
+                          <span className={cn(
+                            'text-sm',
+                            theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+                          )}>
+                            {isZh ? option.zh : option.en}
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* 观察结果 */}
+              {step.observation && (
+                <div className={cn(
+                  'p-4 rounded-xl',
+                  theme === 'dark' ? 'bg-green-500/10' : 'bg-green-50'
+                )}>
+                  <div className="flex items-start gap-2">
+                    <Eye className="w-4 h-4 text-green-500 flex-shrink-0 mt-0.5" />
+                    <p className={cn(
+                      'text-sm',
+                      theme === 'dark' ? 'text-green-300' : 'text-green-800'
+                    )}>
+                      {isZh ? step.observation.zh : step.observation.en}
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              {/* 反思内容 */}
+              {step.reflection && (
+                <div className={cn(
+                  'p-4 rounded-xl',
+                  theme === 'dark' ? 'bg-purple-500/10' : 'bg-purple-50'
+                )}>
+                  <div className="flex items-start gap-2">
+                    <Lightbulb className="w-4 h-4 text-purple-500 flex-shrink-0 mt-0.5" />
+                    <p className={cn(
+                      'text-sm',
+                      theme === 'dark' ? 'text-purple-300' : 'text-purple-800'
+                    )}>
+                      {isZh ? step.reflection.zh : step.reflection.en}
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              {/* 小提示 */}
+              {step.tip && (
+                <p className={cn(
+                  'text-xs flex items-center gap-1.5',
+                  theme === 'dark' ? 'text-gray-500' : 'text-gray-400'
+                )}>
+                  💡 {isZh ? step.tip.zh : step.tip.en}
+                </p>
+              )}
+
+              {/* 导航按钮 */}
+              <div className="flex items-center justify-between pt-4">
+                <button
+                  onClick={goPrev}
+                  className={cn(
+                    'flex items-center gap-1 px-4 py-2 rounded-lg text-sm transition-colors',
+                    theme === 'dark'
+                      ? 'text-gray-400 hover:text-white hover:bg-slate-700'
+                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                  )}
+                >
+                  <ChevronLeft className="w-4 h-4" />
+                  {isZh ? '上一步' : 'Back'}
+                </button>
+                <button
+                  onClick={goNext}
+                  disabled={step.type === 'predict' && !predictions[step.id] && step.prediction?.options}
+                  className={cn(
+                    'flex items-center gap-1 px-4 py-2 rounded-lg text-sm font-medium transition-colors',
+                    'bg-cyan-500 text-white hover:bg-cyan-600',
+                    step.type === 'predict' && !predictions[step.id] && step.prediction?.options
+                      ? 'opacity-50 cursor-not-allowed'
+                      : ''
+                  )}
+                >
+                  {currentStep === totalSteps - 1
+                    ? (isZh ? '完成' : 'Finish')
+                    : (isZh ? '下一步' : 'Next')}
+                  <ChevronRight className="w-4 h-4" />
+                </button>
+              </div>
+            </motion.div>
+          )}
+
+          {/* 完成页 */}
+          {isCompleted && (
+            <motion.div
+              key="completed"
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              className="text-center py-6 space-y-5"
+            >
+              <div className="w-16 h-16 rounded-full bg-green-500 flex items-center justify-center mx-auto">
+                <Check className="w-8 h-8 text-white" />
+              </div>
+              <div>
+                <h3 className={cn(
+                  'text-xl font-bold mb-2',
+                  theme === 'dark' ? 'text-white' : 'text-gray-900'
+                )}>
+                  {isZh ? '实验完成！' : 'Experiment Complete!'}
+                </h3>
+                <p className={cn(
+                  'text-sm',
+                  theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
+                )}>
+                  {isZh ? experiment.conclusion.zh : experiment.conclusion.en}
+                </p>
+              </div>
+
+              {/* 下一步建议 */}
+              {experiment.nextSteps && experiment.nextSteps.length > 0 && (
+                <div className="space-y-2">
+                  <p className={cn(
+                    'text-xs uppercase tracking-wider',
+                    theme === 'dark' ? 'text-gray-500' : 'text-gray-400'
+                  )}>
+                    {isZh ? '继续探索' : 'Continue Exploring'}
+                  </p>
+                  <div className="flex flex-wrap justify-center gap-2">
+                    {experiment.nextSteps.map((next, idx) => (
+                      <Link
+                        key={idx}
+                        to={
+                          next.type === 'demo' ? `/demos/${next.id}` :
+                          next.type === 'game' ? `/games/${next.id}` :
+                          next.type === 'calculator' ? `/calc/${next.id}` :
+                          `/discover?topic=${next.id}`
+                        }
+                        className={cn(
+                          'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
+                          theme === 'dark'
+                            ? 'bg-slate-700 text-gray-300 hover:bg-slate-600'
+                            : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                        )}
+                      >
+                        {isZh ? next.label.zh : next.label.en}
+                        <ExternalLink className="w-3 h-3" />
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* 重做按钮 */}
+              <button
+                onClick={reset}
+                className={cn(
+                  'inline-flex items-center gap-1.5 text-sm transition-colors',
+                  theme === 'dark'
+                    ? 'text-gray-500 hover:text-gray-300'
+                    : 'text-gray-400 hover:text-gray-600'
+                )}
+              >
+                <RefreshCw className="w-4 h-4" />
+                {isZh ? '再做一次' : 'Do it again'}
+              </button>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  )
+}
+
+// 预定义的实验
+export const EXPERIMENTS: Experiment[] = [
+  {
+    id: 'polarizer-sunglasses',
+    title: {
+      en: 'Polarizer Discovery',
+      zh: '偏振片探索'
+    },
+    hook: {
+      en: 'What happens when you stack two polarized sunglasses?',
+      zh: '两副偏振太阳镜叠在一起会发生什么？'
+    },
+    difficulty: 'easy',
+    duration: 5,
+    materials: [
+      {
+        name: { en: 'Polarized sunglasses', zh: '偏振太阳镜' },
+        note: { en: '2 pairs work best', zh: '最好有2副' },
+        alternative: { en: 'LCD screen + 1 pair', zh: '液晶屏+1副眼镜' },
+        icon: '🕶️'
+      },
+      {
+        name: { en: 'Light source', zh: '光源' },
+        note: { en: 'Window or lamp', zh: '窗户或灯' },
+        icon: '💡'
+      }
+    ],
+    steps: [
+      {
+        id: 'setup',
+        type: 'setup',
+        title: { en: 'Get Ready', zh: '准备好' },
+        instruction: {
+          en: 'Hold one pair of polarized sunglasses in front of a light source. Look through them - notice how they darken the view.',
+          zh: '拿一副偏振太阳镜对着光源。透过它们看——注意它们如何让视野变暗。'
+        }
+      },
+      {
+        id: 'predict',
+        type: 'predict',
+        title: { en: 'Make a Prediction', zh: '做个预测' },
+        instruction: {
+          en: 'Now you\'re going to add a second pair of polarized sunglasses. What do you think will happen?',
+          zh: '现在你要加上第二副偏振太阳镜。你觉得会发生什么？'
+        },
+        prediction: {
+          question: {
+            en: 'When you rotate the second pair, will the view get:',
+            zh: '当你旋转第二副眼镜时，视野会：'
+          },
+          options: [
+            { en: 'Always stay the same darkness', zh: '一直保持同样的暗度' },
+            { en: 'Change from light to completely dark', zh: '从亮变到完全黑暗' },
+            { en: 'Get lighter when rotated', zh: '旋转时变亮' }
+          ],
+          correctAnswer: 1
+        }
+      },
+      {
+        id: 'action1',
+        type: 'action',
+        title: { en: 'Stack and Rotate', zh: '叠加并旋转' },
+        instruction: {
+          en: 'Hold both pairs of sunglasses together, looking through both. Slowly rotate one pair while keeping the other still.',
+          zh: '把两副太阳镜放在一起，透过它们看。慢慢旋转其中一副，另一副保持不动。'
+        },
+        tip: {
+          en: 'Rotate slowly - the effect happens every 90°!',
+          zh: '慢慢旋转——效果每90°发生一次！'
+        }
+      },
+      {
+        id: 'observe',
+        type: 'observe',
+        title: { en: 'What Did You See?', zh: '你看到了什么？' },
+        instruction: {
+          en: 'Describe what happened as you rotated the sunglasses.',
+          zh: '描述一下旋转太阳镜时发生了什么。'
+        },
+        observation: {
+          en: 'At some angles the view is normal (light passes through), at others it becomes completely dark (all light is blocked). This happens every 90°!',
+          zh: '在某些角度视野正常（光通过），在其他角度完全变黑（所有光被阻挡）。这每90°发生一次！'
+        }
+      },
+      {
+        id: 'reveal',
+        type: 'reveal',
+        title: { en: 'The Secret', zh: '秘密揭晓' },
+        instruction: {
+          en: 'You just discovered crossed polarizers! When two polarizers are at 90° to each other, no light can pass through. This is how LCD screens work!',
+          zh: '你刚刚发现了交叉偏振片！当两个偏振片互成90°时，没有光能通过。液晶屏就是这样工作的！'
+        },
+        reflection: {
+          en: 'The first polarizer only lets light vibrating in one direction through. If the second polarizer is oriented at 90°, it blocks that direction completely.',
+          zh: '第一个偏振片只让一个方向振动的光通过。如果第二个偏振片旋转90°，它就完全阻挡了这个方向。'
+        }
+      },
+      {
+        id: 'reflect',
+        type: 'reflect',
+        title: { en: 'Think About It', zh: '想一想' },
+        instruction: {
+          en: 'Why do you think polarized sunglasses reduce glare from water or roads?',
+          zh: '你认为偏振太阳镜为什么能减少水面或道路的眩光？'
+        },
+        reflection: {
+          en: 'Light reflected from flat surfaces (like water, roads, or glass) becomes partially polarized. Polarized sunglasses block this horizontally polarized light, reducing glare!',
+          zh: '从平面（如水面、道路或玻璃）反射的光会部分偏振。偏振太阳镜阻挡这种水平偏振光，从而减少眩光！'
+        }
+      }
+    ],
+    conclusion: {
+      en: 'You discovered that polarized light only vibrates in one direction, and polarizers can block or pass light depending on their orientation!',
+      zh: '你发现了偏振光只在一个方向振动，偏振片可以根据它们的方向阻挡或通过光！'
+    },
+    nextSteps: [
+      { type: 'demo', id: 'malus', label: { en: 'See the math', zh: '看看数学公式' } },
+      { type: 'game', id: '2d', label: { en: 'Play a puzzle', zh: '玩个谜题' } }
+    ]
+  }
+]
+
+export default InteractiveExperimentModule

--- a/src/components/discovery/MicroLearningCard.tsx
+++ b/src/components/discovery/MicroLearningCard.tsx
@@ -1,0 +1,493 @@
+/**
+ * MicroLearningCard - 微学习卡片
+ *
+ * 设计理念：
+ * - 每张卡片只传达一个核心概念
+ * - 渐进式深度 - 标题 → 简述 → 深入
+ * - 动手优先 - 鼓励互动而非被动阅读
+ * - 连接性 - 引导到相关内容
+ */
+
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/contexts/ThemeContext'
+import { cn } from '@/lib/utils'
+import { motion, AnimatePresence } from 'framer-motion'
+import {
+  ChevronDown,
+  ChevronUp,
+  ExternalLink,
+  Play,
+  Lightbulb,
+  BookOpen,
+  FlaskConical,
+  Gamepad2,
+  Eye
+} from 'lucide-react'
+
+export type CardType = 'concept' | 'vocabulary' | 'formula' | 'experiment' | 'application' | 'fun-fact'
+
+export interface MicroLearningContent {
+  id: string
+  type: CardType
+  title: { en: string; zh: string }
+  // 一句话核心（总是显示）
+  oneLiner: { en: string; zh: string }
+  // 简单解释（展开后显示）
+  simpleExplanation?: { en: string; zh: string }
+  // 公式（仅公式卡和深度模式）
+  formula?: {
+    latex: string
+    description: { en: string; zh: string }
+  }
+  // 深入内容（深度模式）
+  deepDive?: { en: string; zh: string }
+  // 动手建议
+  tryThis?: { en: string; zh: string }
+  // 相关链接
+  relatedDemo?: string
+  relatedGame?: string
+  relatedCalculator?: string
+  // 视觉元素
+  emoji?: string
+  color?: string
+}
+
+// 卡片类型配置
+const CARD_TYPE_CONFIG: Record<CardType, {
+  icon: React.ReactNode
+  defaultColor: string
+  labelEn: string
+  labelZh: string
+}> = {
+  concept: {
+    icon: <Lightbulb className="w-4 h-4" />,
+    defaultColor: '#22d3ee',
+    labelEn: 'Key Concept',
+    labelZh: '核心概念'
+  },
+  vocabulary: {
+    icon: <BookOpen className="w-4 h-4" />,
+    defaultColor: '#a78bfa',
+    labelEn: 'Vocabulary',
+    labelZh: '术语'
+  },
+  formula: {
+    icon: <span className="text-xs font-bold">f(x)</span>,
+    defaultColor: '#f59e0b',
+    labelEn: 'Formula',
+    labelZh: '公式'
+  },
+  experiment: {
+    icon: <FlaskConical className="w-4 h-4" />,
+    defaultColor: '#10b981',
+    labelEn: 'Experiment',
+    labelZh: '实验'
+  },
+  application: {
+    icon: <Eye className="w-4 h-4" />,
+    defaultColor: '#ec4899',
+    labelEn: 'Application',
+    labelZh: '应用'
+  },
+  'fun-fact': {
+    icon: <span className="text-sm">✨</span>,
+    defaultColor: '#6366f1',
+    labelEn: 'Fun Fact',
+    labelZh: '趣味知识'
+  }
+}
+
+interface MicroLearningCardProps {
+  content: MicroLearningContent
+  depthLevel?: 'simple' | 'formulas' | 'theory'
+  defaultExpanded?: boolean
+  onTryDemo?: () => void
+}
+
+export function MicroLearningCard({
+  content,
+  depthLevel = 'simple',
+  defaultExpanded = false,
+  onTryDemo
+}: MicroLearningCardProps) {
+  const { theme } = useTheme()
+  const { i18n } = useTranslation()
+  const isZh = i18n.language === 'zh'
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded)
+
+  const config = CARD_TYPE_CONFIG[content.type]
+  const color = content.color || config.defaultColor
+
+  const shouldShowFormula = content.formula && depthLevel !== 'simple'
+  const shouldShowDeepDive = content.deepDive && depthLevel === 'theory'
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      className={cn(
+        'rounded-xl border overflow-hidden transition-shadow',
+        isExpanded ? 'shadow-lg' : 'shadow-sm hover:shadow-md',
+        theme === 'dark'
+          ? 'bg-slate-800/80 border-slate-700'
+          : 'bg-white border-gray-200'
+      )}
+    >
+      {/* 卡片头部 - 总是可见 */}
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full text-left"
+      >
+        <div className="p-4 flex items-start gap-3">
+          {/* 类型图标 */}
+          <div
+            className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0 text-white"
+            style={{ backgroundColor: color }}
+          >
+            {content.emoji || config.icon}
+          </div>
+
+          <div className="flex-1 min-w-0">
+            {/* 类型标签 */}
+            <span
+              className="text-[10px] font-medium uppercase tracking-wider"
+              style={{ color }}
+            >
+              {isZh ? config.labelZh : config.labelEn}
+            </span>
+
+            {/* 标题 */}
+            <h3 className={cn(
+              'font-semibold text-sm mt-0.5 mb-1',
+              theme === 'dark' ? 'text-white' : 'text-gray-900'
+            )}>
+              {isZh ? content.title.zh : content.title.en}
+            </h3>
+
+            {/* 一句话核心 */}
+            <p className={cn(
+              'text-sm leading-relaxed',
+              theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
+            )}>
+              {isZh ? content.oneLiner.zh : content.oneLiner.en}
+            </p>
+          </div>
+
+          {/* 展开/收起指示器 */}
+          <div className={cn(
+            'flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center transition-colors',
+            theme === 'dark' ? 'bg-slate-700' : 'bg-gray-100'
+          )}>
+            {isExpanded ? (
+              <ChevronUp className="w-4 h-4" style={{ color }} />
+            ) : (
+              <ChevronDown className="w-4 h-4" style={{ color }} />
+            )}
+          </div>
+        </div>
+      </button>
+
+      {/* 展开内容 */}
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <div className={cn(
+              'px-4 pb-4 space-y-4',
+              theme === 'dark' ? 'border-t border-slate-700' : 'border-t border-gray-100'
+            )}>
+              {/* 简单解释 */}
+              {content.simpleExplanation && (
+                <div className="pt-4">
+                  <p className={cn(
+                    'text-sm leading-relaxed',
+                    theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+                  )}>
+                    {isZh ? content.simpleExplanation.zh : content.simpleExplanation.en}
+                  </p>
+                </div>
+              )}
+
+              {/* 公式 */}
+              {shouldShowFormula && content.formula && (
+                <div className={cn(
+                  'p-3 rounded-lg',
+                  theme === 'dark' ? 'bg-slate-900' : 'bg-gray-50'
+                )}>
+                  <div className="font-mono text-center text-lg mb-2" style={{ color }}>
+                    {content.formula.latex}
+                  </div>
+                  <p className={cn(
+                    'text-xs text-center',
+                    theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+                  )}>
+                    {isZh ? content.formula.description.zh : content.formula.description.en}
+                  </p>
+                </div>
+              )}
+
+              {/* 深入内容 */}
+              {shouldShowDeepDive && content.deepDive && (
+                <div className={cn(
+                  'p-3 rounded-lg border-l-2',
+                  theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-50'
+                )} style={{ borderColor: color }}>
+                  <p className={cn(
+                    'text-xs leading-relaxed',
+                    theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
+                  )}>
+                    {isZh ? content.deepDive.zh : content.deepDive.en}
+                  </p>
+                </div>
+              )}
+
+              {/* 动手试试 */}
+              {content.tryThis && (
+                <div className={cn(
+                  'p-3 rounded-lg flex items-start gap-2',
+                  theme === 'dark' ? 'bg-amber-500/10' : 'bg-amber-50'
+                )}>
+                  <Lightbulb className="w-4 h-4 text-amber-500 flex-shrink-0 mt-0.5" />
+                  <p className={cn(
+                    'text-sm',
+                    theme === 'dark' ? 'text-amber-300' : 'text-amber-800'
+                  )}>
+                    {isZh ? content.tryThis.zh : content.tryThis.en}
+                  </p>
+                </div>
+              )}
+
+              {/* 相关链接 */}
+              <div className="flex flex-wrap gap-2 pt-2">
+                {content.relatedDemo && (
+                  <Link
+                    to={`/demos/${content.relatedDemo}`}
+                    className={cn(
+                      'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
+                      theme === 'dark'
+                        ? 'bg-slate-700 text-cyan-400 hover:bg-slate-600'
+                        : 'bg-cyan-50 text-cyan-700 hover:bg-cyan-100'
+                    )}
+                  >
+                    <Play className="w-3 h-3" />
+                    {isZh ? '互动演示' : 'Demo'}
+                  </Link>
+                )}
+                {content.relatedGame && (
+                  <Link
+                    to={content.relatedGame}
+                    className={cn(
+                      'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
+                      theme === 'dark'
+                        ? 'bg-slate-700 text-pink-400 hover:bg-slate-600'
+                        : 'bg-pink-50 text-pink-700 hover:bg-pink-100'
+                    )}
+                  >
+                    <Gamepad2 className="w-3 h-3" />
+                    {isZh ? '游戏挑战' : 'Game'}
+                  </Link>
+                )}
+                {content.relatedCalculator && (
+                  <Link
+                    to={content.relatedCalculator}
+                    className={cn(
+                      'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
+                      theme === 'dark'
+                        ? 'bg-slate-700 text-purple-400 hover:bg-slate-600'
+                        : 'bg-purple-50 text-purple-700 hover:bg-purple-100'
+                    )}
+                  >
+                    <span className="text-xs">f(x)</span>
+                    {isZh ? '计算器' : 'Calculator'}
+                  </Link>
+                )}
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.div>
+  )
+}
+
+// 预定义的微学习内容
+export const MICRO_LEARNING_CARDS: MicroLearningContent[] = [
+  {
+    id: 'what-is-polarization',
+    type: 'concept',
+    title: {
+      en: 'What is Polarization?',
+      zh: '什么是偏振？'
+    },
+    oneLiner: {
+      en: 'Light waves vibrating in a single direction instead of all directions.',
+      zh: '光波只在一个方向振动，而不是所有方向。'
+    },
+    simpleExplanation: {
+      en: 'Imagine shaking a rope. You can shake it up and down, left and right, or any direction. Ordinary light is like shaking in all directions at once. Polarized light is like shaking in just one direction.',
+      zh: '想象抖动一根绳子。你可以上下抖、左右抖或任何方向。普通光就像同时向所有方向抖。偏振光就像只向一个方向抖。'
+    },
+    tryThis: {
+      en: 'Try rotating polarized sunglasses while looking at your phone screen!',
+      zh: '试试戴着偏振太阳镜旋转着看手机屏幕！'
+    },
+    relatedDemo: 'polarization-intro',
+    emoji: '〰️'
+  },
+  {
+    id: 'malus-law',
+    type: 'formula',
+    title: {
+      en: "Malus's Law",
+      zh: '马吕斯定律'
+    },
+    oneLiner: {
+      en: 'The intensity of light through a polarizer depends on the angle.',
+      zh: '通过偏振片的光强度取决于角度。'
+    },
+    simpleExplanation: {
+      en: "When polarized light hits a polarizer at an angle, some light gets blocked. The more tilted, the less light passes through. At 90°, no light passes at all!",
+      zh: '当偏振光以一定角度照射偏振片时，部分光被阻挡。倾斜越大，通过的光越少。在90°时，完全没有光通过！'
+    },
+    formula: {
+      latex: 'I = I₀ cos²(θ)',
+      description: {
+        en: 'I = transmitted intensity, I₀ = initial intensity, θ = angle between polarization and filter',
+        zh: 'I = 透射强度，I₀ = 初始强度，θ = 偏振方向与滤光片的夹角'
+      }
+    },
+    deepDive: {
+      en: 'This law was discovered by Étienne-Louis Malus in 1809 when he observed light reflected from a window through a calcite crystal. The cos² dependence comes from projecting the electric field vector onto the transmission axis.',
+      zh: '这个定律是马吕斯在1809年通过方解石晶体观察窗户反射光时发现的。cos²的关系来自将电场矢量投影到透光轴上。'
+    },
+    relatedDemo: 'malus',
+    relatedCalculator: '/calc/jones',
+    color: '#f59e0b'
+  },
+  {
+    id: 'birefringence',
+    type: 'vocabulary',
+    title: {
+      en: 'Birefringence',
+      zh: '双折射'
+    },
+    oneLiner: {
+      en: 'A crystal that splits light into two beams with different polarizations.',
+      zh: '一种将光分成两束不同偏振光的晶体。'
+    },
+    simpleExplanation: {
+      en: 'Some crystals, like calcite, have different "speeds" for light vibrating in different directions. This causes one ray to bend more than the other, creating two images!',
+      zh: '某些晶体（如方解石）对不同方向振动的光有不同的"速度"。这导致一束光比另一束弯曲更多，产生两个像！'
+    },
+    tryThis: {
+      en: 'Put a clear calcite crystal over text - you\'ll see double!',
+      zh: '把透明方解石放在文字上——你会看到双影！'
+    },
+    relatedDemo: 'birefringence',
+    emoji: '💎'
+  },
+  {
+    id: 'rayleigh-scattering',
+    type: 'concept',
+    title: {
+      en: 'Why is the sky blue?',
+      zh: '天空为什么是蓝色的？'
+    },
+    oneLiner: {
+      en: 'Small molecules scatter blue light more than red light.',
+      zh: '小分子散射蓝光比红光更多。'
+    },
+    simpleExplanation: {
+      en: 'Air molecules are much smaller than light wavelengths. They bounce short (blue) waves more than long (red) waves. That\'s why we see blue sky overhead and red sunsets when light travels through more atmosphere.',
+      zh: '空气分子比光波长小得多。它们弹射短波（蓝色）比长波（红色）更多。这就是我们在头顶看到蓝天，在光穿过更多大气时看到红色日落的原因。'
+    },
+    formula: {
+      latex: 'I ∝ 1/λ⁴',
+      description: {
+        en: 'Scattering intensity is inversely proportional to the 4th power of wavelength',
+        zh: '散射强度与波长的四次方成反比'
+      }
+    },
+    relatedDemo: 'rayleigh',
+    color: '#3b82f6'
+  },
+  {
+    id: 'lcd-polarization',
+    type: 'application',
+    title: {
+      en: 'LCD Screens',
+      zh: '液晶显示屏'
+    },
+    oneLiner: {
+      en: 'Your phone screen uses polarizers to control what you see.',
+      zh: '你的手机屏幕使用偏振片来控制显示内容。'
+    },
+    simpleExplanation: {
+      en: 'LCD screens have two polarizers at 90° to each other (normally blocking all light). Liquid crystals between them twist the light\'s polarization, letting it through. Electrically controlled pixels decide which areas are bright or dark.',
+      zh: '液晶屏有两个互成90°的偏振片（通常阻挡所有光）。它们之间的液晶会扭转光的偏振，让光通过。电控像素决定哪些区域明亮或黑暗。'
+    },
+    tryThis: {
+      en: 'Look at an LCD through polarized sunglasses and rotate them - the screen will appear to turn on and off!',
+      zh: '透过偏振太阳镜看液晶屏并旋转眼镜——屏幕会看起来忽明忽暗！'
+    },
+    relatedDemo: 'polarization-types-unified',
+    emoji: '📱'
+  }
+]
+
+// 卡片组组件
+export function MicroLearningCardStack({
+  cards,
+  depthLevel = 'simple',
+  maxVisible = 3
+}: {
+  cards: MicroLearningContent[]
+  depthLevel?: 'simple' | 'formulas' | 'theory'
+  maxVisible?: number
+}) {
+  const { theme } = useTheme()
+  const { i18n } = useTranslation()
+  const isZh = i18n.language === 'zh'
+  const [showAll, setShowAll] = useState(false)
+
+  const visibleCards = showAll ? cards : cards.slice(0, maxVisible)
+  const hasMore = cards.length > maxVisible
+
+  return (
+    <div className="space-y-3">
+      {visibleCards.map(card => (
+        <MicroLearningCard
+          key={card.id}
+          content={card}
+          depthLevel={depthLevel}
+        />
+      ))}
+
+      {hasMore && !showAll && (
+        <button
+          onClick={() => setShowAll(true)}
+          className={cn(
+            'w-full py-3 rounded-xl border-2 border-dashed text-sm font-medium transition-colors',
+            theme === 'dark'
+              ? 'border-slate-700 text-gray-400 hover:border-slate-600 hover:text-gray-300'
+              : 'border-gray-200 text-gray-500 hover:border-gray-300 hover:text-gray-700'
+          )}
+        >
+          {isZh
+            ? `显示更多 (${cards.length - maxVisible})`
+            : `Show more (${cards.length - maxVisible})`}
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default MicroLearningCard

--- a/src/components/discovery/index.ts
+++ b/src/components/discovery/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Discovery Components - 渐进式探索组件
+ *
+ * 设计理念来自 Google Learn About:
+ * - 问题驱动的入口
+ * - 渐进式信息披露
+ * - 主动学习检查点
+ * - 深度控制（简化/深入）
+ */
+
+// 微学习卡片
+export {
+  MicroLearningCard,
+  MicroLearningCardStack,
+  MICRO_LEARNING_CARDS,
+  type MicroLearningContent,
+  type CardType
+} from './MicroLearningCard'
+
+// 互动实验模块
+export {
+  InteractiveExperimentModule,
+  EXPERIMENTS,
+  type Experiment
+} from './InteractiveExperimentModule'
+
+// 引导探索路径
+export { GuidedExplorationPath } from './GuidedExplorationPath'

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -1,0 +1,1000 @@
+/**
+ * DiscoveryPage - 渐进式探索入口
+ *
+ * 设计理念 (参考 Google Learn About):
+ * 1. 以问题和好奇心为入口，而非信息菜单
+ * 2. 渐进式披露 - 先展示核心体验，深度内容按需展开
+ * 3. Stop & Think 检查点 - 促进主动思考
+ * 4. 深度控制 - 简化/深入按钮
+ * 5. 相关发现 - 引导网状探索
+ *
+ * 核心原则：
+ * - 避免信息过载
+ * - 引导式探索
+ * - 动手优先
+ */
+
+import { useState, useEffect, useMemo } from 'react'
+import { Link, useSearchParams, useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/contexts/ThemeContext'
+import { cn } from '@/lib/utils'
+import { motion, AnimatePresence } from 'framer-motion'
+import {
+  Sparkles,
+  Eye,
+  ChevronRight,
+  ChevronDown,
+  Play,
+  Lightbulb,
+  BookOpen,
+  Gamepad2,
+  FlaskConical,
+  ArrowRight,
+  ArrowLeft,
+  Compass,
+  HelpCircle,
+  Check,
+  RefreshCw,
+  Minus,
+  Plus,
+  X,
+  MessageCircle
+} from 'lucide-react'
+import { LanguageThemeSwitcher } from '@/components/ui/LanguageThemeSwitcher'
+import { PersistentHeader } from '@/components/shared/PersistentHeader'
+
+// 发现主题定义 - 每个主题聚焦一个核心问题
+interface DiscoveryTopic {
+  id: string
+  question: { en: string; zh: string }
+  teaser: { en: string; zh: string }
+  emoji: string
+  color: string
+  stage: 1 | 2 | 3
+  // 核心体验 - 最小化入口
+  quickDemo?: string  // Demo ID for instant gratification
+  // 扩展内容
+  relatedTopics: string[]
+}
+
+// 精选的发现主题 - 按学习阶段组织
+const DISCOVERY_TOPICS: DiscoveryTopic[] = [
+  // 阶段1: 看见偏振
+  {
+    id: 'sunglasses-magic',
+    question: {
+      en: 'Why do polarized sunglasses reduce glare?',
+      zh: '偏振太阳镜为什么能减少眩光？'
+    },
+    teaser: {
+      en: 'Tilt your head while wearing polarized sunglasses near water...',
+      zh: '戴着偏振太阳镜在水边歪头试试...'
+    },
+    emoji: '🕶️',
+    color: '#22c55e',
+    stage: 1,
+    quickDemo: 'polarization-intro',
+    relatedTopics: ['lcd-screen', 'photography-filter']
+  },
+  {
+    id: 'lcd-screen',
+    question: {
+      en: 'Why does your phone screen go dark when tilted?',
+      zh: '手机屏幕为什么歪着看会变暗？'
+    },
+    teaser: {
+      en: 'Try looking at an LCD through polarized sunglasses...',
+      zh: '试试透过偏振太阳镜看液晶屏...'
+    },
+    emoji: '📱',
+    color: '#06b6d4',
+    stage: 1,
+    quickDemo: 'polarization-types-unified',
+    relatedTopics: ['sunglasses-magic', 'three-polarizers']
+  },
+  {
+    id: 'three-polarizers',
+    question: {
+      en: 'Can adding a filter let MORE light through?',
+      zh: '加一片滤镜反而能让更多光通过？'
+    },
+    teaser: {
+      en: 'This paradox surprised even Einstein!',
+      zh: '这个悖论连爱因斯坦都惊讶！'
+    },
+    emoji: '🔮',
+    color: '#8b5cf6',
+    stage: 1,
+    quickDemo: 'malus',
+    relatedTopics: ['lcd-screen', 'quantum-eraser']
+  },
+  // 阶段2: 理解规律
+  {
+    id: 'rainbow-crystal',
+    question: {
+      en: 'How does a crystal create two images?',
+      zh: '一块晶体怎么能产生两个像？'
+    },
+    teaser: {
+      en: 'Calcite creates magic right on your desk',
+      zh: '方解石在你桌上就能变魔术'
+    },
+    emoji: '💎',
+    color: '#f59e0b',
+    stage: 2,
+    quickDemo: 'birefringence',
+    relatedTopics: ['waveplate-magic', 'stress-patterns']
+  },
+  {
+    id: 'waveplate-magic',
+    question: {
+      en: 'How can you twist light without touching it?',
+      zh: '怎么不碰光就能扭转它？'
+    },
+    teaser: {
+      en: 'Waveplates are the Swiss army knife of optics',
+      zh: '波片是光学界的瑞士军刀'
+    },
+    emoji: '🌀',
+    color: '#ec4899',
+    stage: 2,
+    quickDemo: 'waveplate',
+    relatedTopics: ['rainbow-crystal', 'circular-polarization']
+  },
+  {
+    id: 'sky-blue',
+    question: {
+      en: 'Why is the sky blue? (And why is sunset red?)',
+      zh: '天空为什么是蓝色的？（日落为什么是红色的？）'
+    },
+    teaser: {
+      en: 'The answer involves dancing molecules and scattered light',
+      zh: '答案涉及跳舞的分子和散射的光'
+    },
+    emoji: '🌅',
+    color: '#3b82f6',
+    stage: 2,
+    quickDemo: 'rayleigh',
+    relatedTopics: ['polarized-sky', 'bee-navigation']
+  },
+  // 阶段3: 测量与应用
+  {
+    id: 'stress-patterns',
+    question: {
+      en: 'How can you see stress in transparent plastic?',
+      zh: '怎么能看到透明塑料里的应力？'
+    },
+    teaser: {
+      en: 'Engineers use this to prevent disasters',
+      zh: '工程师用这个来预防灾难'
+    },
+    emoji: '🔬',
+    color: '#6366f1',
+    stage: 3,
+    quickDemo: 'chromatic',
+    relatedTopics: ['rainbow-crystal', 'medical-imaging']
+  },
+  {
+    id: 'medical-imaging',
+    question: {
+      en: 'How do doctors see through your skin?',
+      zh: '医生怎么能看穿你的皮肤？'
+    },
+    teaser: {
+      en: 'Polarized light reveals what\'s invisible to the eye',
+      zh: '偏振光揭示肉眼看不见的东西'
+    },
+    emoji: '🏥',
+    color: '#10b981',
+    stage: 3,
+    quickDemo: 'mie-scattering',
+    relatedTopics: ['stress-patterns', 'astronomy']
+  }
+]
+
+// 当前发现状态
+interface DiscoveryState {
+  currentTopicId: string | null
+  expandedSections: string[]
+  completedCheckpoints: string[]
+  depthLevel: 'simple' | 'formulas' | 'theory'
+}
+
+// 入口卡片组件 - 单个问题入口
+function QuestionEntryCard({
+  topic,
+  onClick,
+  isActive
+}: {
+  topic: DiscoveryTopic
+  onClick: () => void
+  isActive: boolean
+}) {
+  const { theme } = useTheme()
+  const { i18n } = useTranslation()
+  const isZh = i18n.language === 'zh'
+
+  return (
+    <motion.button
+      onClick={onClick}
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      whileHover={{ scale: 1.02, y: -2 }}
+      whileTap={{ scale: 0.98 }}
+      className={cn(
+        'relative p-5 rounded-2xl text-left transition-all border-2',
+        'group cursor-pointer overflow-hidden',
+        theme === 'dark'
+          ? 'bg-slate-800/60 hover:bg-slate-800'
+          : 'bg-white/80 hover:bg-white shadow-sm hover:shadow-md',
+        isActive ? 'ring-2 ring-offset-2' : ''
+      )}
+      style={{
+        borderColor: isActive ? topic.color : 'transparent',
+        // @ts-ignore
+        '--ring-color': topic.color
+      }}
+    >
+      {/* 背景装饰 */}
+      <div
+        className="absolute top-0 right-0 w-24 h-24 rounded-full opacity-10 blur-2xl"
+        style={{ backgroundColor: topic.color }}
+      />
+
+      {/* Emoji */}
+      <span className="text-3xl mb-3 block">{topic.emoji}</span>
+
+      {/* 问题 */}
+      <h3 className={cn(
+        'font-semibold text-base mb-2 leading-snug',
+        theme === 'dark' ? 'text-white' : 'text-gray-900'
+      )}>
+        {isZh ? topic.question.zh : topic.question.en}
+      </h3>
+
+      {/* 引子 */}
+      <p className={cn(
+        'text-sm leading-relaxed',
+        theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
+      )}>
+        {isZh ? topic.teaser.zh : topic.teaser.en}
+      </p>
+
+      {/* 探索箭头 */}
+      <div className={cn(
+        'absolute bottom-4 right-4 w-8 h-8 rounded-full flex items-center justify-center',
+        'opacity-0 group-hover:opacity-100 transition-opacity',
+        theme === 'dark' ? 'bg-white/10' : 'bg-gray-100'
+      )}>
+        <ArrowRight className="w-4 h-4" style={{ color: topic.color }} />
+      </div>
+
+      {/* 阶段标识 */}
+      <div
+        className="absolute top-3 right-3 w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold text-white"
+        style={{ backgroundColor: topic.color }}
+      >
+        {topic.stage}
+      </div>
+    </motion.button>
+  )
+}
+
+// Stop & Think 检查点组件
+function StopAndThink({
+  question,
+  hint,
+  onComplete,
+  isCompleted
+}: {
+  question: { en: string; zh: string }
+  hint?: { en: string; zh: string }
+  onComplete: () => void
+  isCompleted: boolean
+}) {
+  const { theme } = useTheme()
+  const { i18n } = useTranslation()
+  const isZh = i18n.language === 'zh'
+  const [showHint, setShowHint] = useState(false)
+  const [userThinking, setUserThinking] = useState(false)
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      className={cn(
+        'p-4 rounded-xl border-l-4 border-amber-500',
+        theme === 'dark'
+          ? 'bg-amber-500/10'
+          : 'bg-amber-50'
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <div className="w-8 h-8 rounded-full bg-amber-500 flex items-center justify-center flex-shrink-0">
+          <Lightbulb className="w-4 h-4 text-white" />
+        </div>
+        <div className="flex-1">
+          <h4 className={cn(
+            'font-medium text-sm mb-2',
+            theme === 'dark' ? 'text-amber-400' : 'text-amber-700'
+          )}>
+            {isZh ? '停下来想一想' : 'Stop & Think'}
+          </h4>
+          <p className={cn(
+            'text-sm mb-3',
+            theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+          )}>
+            {isZh ? question.zh : question.en}
+          </p>
+
+          {/* 互动按钮 */}
+          <div className="flex items-center gap-2 flex-wrap">
+            {!isCompleted && (
+              <>
+                <button
+                  onClick={() => setUserThinking(true)}
+                  className={cn(
+                    'px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
+                    userThinking
+                      ? 'bg-amber-500 text-white'
+                      : theme === 'dark'
+                        ? 'bg-slate-700 text-gray-300 hover:bg-slate-600'
+                        : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                  )}
+                >
+                  {isZh ? '我在思考...' : "I'm thinking..."}
+                </button>
+                {userThinking && (
+                  <motion.button
+                    initial={{ opacity: 0, scale: 0.9 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    onClick={onComplete}
+                    className="px-3 py-1.5 rounded-lg text-xs font-medium bg-green-500 text-white hover:bg-green-600 transition-colors"
+                  >
+                    {isZh ? '我想好了！' : 'Got it!'}
+                  </motion.button>
+                )}
+              </>
+            )}
+            {isCompleted && (
+              <span className="flex items-center gap-1 text-xs text-green-500">
+                <Check className="w-3 h-3" />
+                {isZh ? '已完成思考' : 'Thought through'}
+              </span>
+            )}
+            {hint && !isCompleted && (
+              <button
+                onClick={() => setShowHint(!showHint)}
+                className={cn(
+                  'px-3 py-1.5 rounded-lg text-xs transition-colors',
+                  theme === 'dark'
+                    ? 'text-gray-400 hover:text-gray-300'
+                    : 'text-gray-500 hover:text-gray-700'
+                )}
+              >
+                {showHint
+                  ? (isZh ? '隐藏提示' : 'Hide hint')
+                  : (isZh ? '给我提示' : 'Give me a hint')}
+              </button>
+            )}
+          </div>
+
+          {/* 提示内容 */}
+          <AnimatePresence>
+            {showHint && hint && (
+              <motion.p
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: 'auto' }}
+                exit={{ opacity: 0, height: 0 }}
+                className={cn(
+                  'text-xs mt-2 pt-2 border-t',
+                  theme === 'dark'
+                    ? 'text-gray-400 border-gray-700'
+                    : 'text-gray-600 border-gray-200'
+                )}
+              >
+                💡 {isZh ? hint.zh : hint.en}
+              </motion.p>
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+    </motion.div>
+  )
+}
+
+// 深度控制按钮
+function DepthControls({
+  currentDepth,
+  onDepthChange
+}: {
+  currentDepth: 'simple' | 'formulas' | 'theory'
+  onDepthChange: (depth: 'simple' | 'formulas' | 'theory') => void
+}) {
+  const { theme } = useTheme()
+  const { i18n } = useTranslation()
+  const isZh = i18n.language === 'zh'
+
+  const depths = [
+    { key: 'simple' as const, label: isZh ? '简单' : 'Simple', icon: <Eye className="w-3 h-3" /> },
+    { key: 'formulas' as const, label: isZh ? '公式' : 'Formulas', icon: <BookOpen className="w-3 h-3" /> },
+    { key: 'theory' as const, label: isZh ? '理论' : 'Theory', icon: <FlaskConical className="w-3 h-3" /> }
+  ]
+
+  return (
+    <div className={cn(
+      'inline-flex items-center gap-1 p-1 rounded-lg',
+      theme === 'dark' ? 'bg-slate-800' : 'bg-gray-100'
+    )}>
+      {depths.map(depth => (
+        <button
+          key={depth.key}
+          onClick={() => onDepthChange(depth.key)}
+          className={cn(
+            'flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-all',
+            currentDepth === depth.key
+              ? 'bg-cyan-500 text-white shadow-sm'
+              : theme === 'dark'
+                ? 'text-gray-400 hover:text-white hover:bg-slate-700'
+                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-200'
+          )}
+        >
+          {depth.icon}
+          {depth.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+// 微型演示卡片 - 简化版demo入口
+function MiniDemoCard({
+  demoId,
+  topic,
+  onExpand
+}: {
+  demoId: string
+  topic: DiscoveryTopic
+  onExpand: () => void
+}) {
+  const { theme } = useTheme()
+  const { i18n } = useTranslation()
+  const isZh = i18n.language === 'zh'
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      className={cn(
+        'p-4 rounded-xl border',
+        theme === 'dark'
+          ? 'bg-slate-800/50 border-slate-700'
+          : 'bg-white border-gray-200'
+      )}
+    >
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <div
+            className="w-8 h-8 rounded-lg flex items-center justify-center"
+            style={{ backgroundColor: `${topic.color}20` }}
+          >
+            <Play className="w-4 h-4" style={{ color: topic.color }} />
+          </div>
+          <span className={cn(
+            'text-sm font-medium',
+            theme === 'dark' ? 'text-white' : 'text-gray-900'
+          )}>
+            {isZh ? '动手试试' : 'Try it yourself'}
+          </span>
+        </div>
+        <Link
+          to={`/demos/${demoId}`}
+          className={cn(
+            'text-xs px-3 py-1 rounded-full transition-colors',
+            theme === 'dark'
+              ? 'bg-slate-700 text-gray-300 hover:bg-slate-600'
+              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+          )}
+        >
+          {isZh ? '全屏演示' : 'Full demo'} →
+        </Link>
+      </div>
+
+      {/* 嵌入式演示预览区 */}
+      <div
+        className={cn(
+          'aspect-video rounded-lg flex items-center justify-center cursor-pointer group',
+          theme === 'dark' ? 'bg-slate-900' : 'bg-gray-100'
+        )}
+        onClick={onExpand}
+      >
+        <div className="text-center">
+          <div
+            className="w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-2 group-hover:scale-110 transition-transform"
+            style={{ backgroundColor: `${topic.color}20` }}
+          >
+            <Play className="w-6 h-6" style={{ color: topic.color }} />
+          </div>
+          <p className={cn(
+            'text-xs',
+            theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
+          )}>
+            {isZh ? '点击开始互动' : 'Click to interact'}
+          </p>
+        </div>
+      </div>
+    </motion.div>
+  )
+}
+
+// 相关发现组件
+function RelatedDiscoveries({
+  topics,
+  currentTopicId,
+  onSelect
+}: {
+  topics: DiscoveryTopic[]
+  currentTopicId: string
+  onSelect: (topicId: string) => void
+}) {
+  const { theme } = useTheme()
+  const { i18n } = useTranslation()
+  const isZh = i18n.language === 'zh'
+
+  const currentTopic = topics.find(t => t.id === currentTopicId)
+  const relatedTopics = currentTopic?.relatedTopics
+    .map(id => topics.find(t => t.id === id))
+    .filter(Boolean) as DiscoveryTopic[]
+
+  if (!relatedTopics?.length) return null
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      className={cn(
+        'p-4 rounded-xl',
+        theme === 'dark' ? 'bg-slate-800/30' : 'bg-gray-50'
+      )}
+    >
+      <h4 className={cn(
+        'text-sm font-medium mb-3 flex items-center gap-2',
+        theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+      )}>
+        <MessageCircle className="w-4 h-4" />
+        {isZh ? '你可能也想知道...' : 'You might also wonder...'}
+      </h4>
+      <div className="space-y-2">
+        {relatedTopics.map(topic => (
+          <button
+            key={topic.id}
+            onClick={() => onSelect(topic.id)}
+            className={cn(
+              'w-full text-left p-3 rounded-lg flex items-center gap-3 transition-colors group',
+              theme === 'dark'
+                ? 'hover:bg-slate-700/50'
+                : 'hover:bg-white'
+            )}
+          >
+            <span className="text-xl">{topic.emoji}</span>
+            <span className={cn(
+              'text-sm flex-1',
+              theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+            )}>
+              {isZh ? topic.question.zh : topic.question.en}
+            </span>
+            <ChevronRight
+              className="w-4 h-4 opacity-0 group-hover:opacity-100 transition-opacity"
+              style={{ color: topic.color }}
+            />
+          </button>
+        ))}
+      </div>
+    </motion.div>
+  )
+}
+
+// 学习阶段导航
+function StageNavigator({
+  currentStage,
+  onStageChange
+}: {
+  currentStage: 1 | 2 | 3 | null
+  onStageChange: (stage: 1 | 2 | 3 | null) => void
+}) {
+  const { theme } = useTheme()
+  const { i18n } = useTranslation()
+  const isZh = i18n.language === 'zh'
+
+  const stages = [
+    { num: 1, label: isZh ? '看见偏振' : 'See', color: '#22c55e', icon: '👁️' },
+    { num: 2, label: isZh ? '理解规律' : 'Understand', color: '#06b6d4', icon: '📐' },
+    { num: 3, label: isZh ? '测量应用' : 'Apply', color: '#8b5cf6', icon: '🔬' }
+  ] as const
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        onClick={() => onStageChange(null)}
+        className={cn(
+          'px-3 py-1.5 rounded-full text-xs font-medium transition-colors',
+          currentStage === null
+            ? 'bg-gray-500 text-white'
+            : theme === 'dark'
+              ? 'bg-slate-800 text-gray-400 hover:text-white'
+              : 'bg-gray-100 text-gray-600 hover:text-gray-900'
+        )}
+      >
+        {isZh ? '全部' : 'All'}
+      </button>
+      {stages.map(stage => (
+        <button
+          key={stage.num}
+          onClick={() => onStageChange(stage.num)}
+          className={cn(
+            'px-3 py-1.5 rounded-full text-xs font-medium transition-colors flex items-center gap-1.5',
+            currentStage === stage.num
+              ? 'text-white'
+              : theme === 'dark'
+                ? 'bg-slate-800 text-gray-400 hover:text-white'
+                : 'bg-gray-100 text-gray-600 hover:text-gray-900'
+          )}
+          style={{
+            backgroundColor: currentStage === stage.num ? stage.color : undefined
+          }}
+        >
+          <span>{stage.icon}</span>
+          <span className="hidden sm:inline">{stage.label}</span>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+// 主页面组件
+export default function DiscoveryPage() {
+  const { theme } = useTheme()
+  const { i18n } = useTranslation()
+  const isZh = i18n.language === 'zh'
+  const [searchParams, setSearchParams] = useSearchParams()
+  const navigate = useNavigate()
+
+  // 状态
+  const [selectedTopicId, setSelectedTopicId] = useState<string | null>(
+    searchParams.get('topic')
+  )
+  const [filterStage, setFilterStage] = useState<1 | 2 | 3 | null>(null)
+  const [depthLevel, setDepthLevel] = useState<'simple' | 'formulas' | 'theory'>('simple')
+  const [completedCheckpoints, setCompletedCheckpoints] = useState<string[]>([])
+  const [showDemoModal, setShowDemoModal] = useState(false)
+
+  // 更新URL
+  useEffect(() => {
+    if (selectedTopicId) {
+      setSearchParams({ topic: selectedTopicId })
+    } else {
+      setSearchParams({})
+    }
+  }, [selectedTopicId, setSearchParams])
+
+  // 筛选主题
+  const filteredTopics = useMemo(() => {
+    if (filterStage === null) return DISCOVERY_TOPICS
+    return DISCOVERY_TOPICS.filter(t => t.stage === filterStage)
+  }, [filterStage])
+
+  const selectedTopic = DISCOVERY_TOPICS.find(t => t.id === selectedTopicId)
+
+  // 处理检查点完成
+  const handleCheckpointComplete = (checkpointId: string) => {
+    setCompletedCheckpoints(prev => [...prev, checkpointId])
+  }
+
+  return (
+    <div className={cn(
+      'min-h-screen',
+      theme === 'dark' ? 'bg-slate-900' : 'bg-gray-50'
+    )}>
+      <PersistentHeader />
+
+      <main className="max-w-6xl mx-auto px-4 py-8">
+        {/* 页面标题 */}
+        <div className="text-center mb-8">
+          <motion.h1
+            initial={{ opacity: 0, y: -20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className={cn(
+              'text-3xl md:text-4xl font-bold mb-3',
+              theme === 'dark' ? 'text-white' : 'text-gray-900'
+            )}
+          >
+            {isZh ? '发现偏振' : 'Discover Polarization'}
+          </motion.h1>
+          <motion.p
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1, delay: 0.1 }}
+            className={cn(
+              'text-lg',
+              theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
+            )}
+          >
+            {isZh
+              ? '从一个问题开始，探索光的隐藏世界'
+              : 'Start with a question, explore the hidden world of light'}
+          </motion.p>
+        </div>
+
+        {/* 控制栏 */}
+        <div className="flex flex-wrap items-center justify-between gap-4 mb-8">
+          <StageNavigator
+            currentStage={filterStage}
+            onStageChange={setFilterStage}
+          />
+          <div className="flex items-center gap-3">
+            <DepthControls
+              currentDepth={depthLevel}
+              onDepthChange={setDepthLevel}
+            />
+            <LanguageThemeSwitcher />
+          </div>
+        </div>
+
+        {/* 主内容区 */}
+        <AnimatePresence mode="wait">
+          {!selectedTopicId ? (
+            // 问题网格视图
+            <motion.div
+              key="grid"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+            >
+              {/* 引导提示 */}
+              <div className={cn(
+                'text-center py-6 mb-6 rounded-2xl',
+                theme === 'dark' ? 'bg-slate-800/30' : 'bg-white/50'
+              )}>
+                <Compass className={cn(
+                  'w-8 h-8 mx-auto mb-3',
+                  theme === 'dark' ? 'text-cyan-400' : 'text-cyan-600'
+                )} />
+                <p className={cn(
+                  'text-sm',
+                  theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
+                )}>
+                  {isZh
+                    ? '选择一个让你好奇的问题，开始你的探索之旅'
+                    : 'Pick a question that makes you curious to start your journey'}
+                </p>
+              </div>
+
+              {/* 问题卡片网格 */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {filteredTopics.map(topic => (
+                  <QuestionEntryCard
+                    key={topic.id}
+                    topic={topic}
+                    onClick={() => setSelectedTopicId(topic.id)}
+                    isActive={false}
+                  />
+                ))}
+              </div>
+
+              {/* 底部链接 */}
+              <div className="mt-8 text-center">
+                <Link
+                  to="/demos"
+                  className={cn(
+                    'inline-flex items-center gap-2 text-sm transition-colors',
+                    theme === 'dark'
+                      ? 'text-gray-500 hover:text-gray-300'
+                      : 'text-gray-400 hover:text-gray-600'
+                  )}
+                >
+                  {isZh ? '想看完整演示目录？' : 'Want the full demo catalog?'}
+                  <ArrowRight className="w-4 h-4" />
+                </Link>
+              </div>
+            </motion.div>
+          ) : (
+            // 探索详情视图
+            <motion.div
+              key="detail"
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -20 }}
+              className="max-w-3xl mx-auto"
+            >
+              {/* 返回按钮 */}
+              <button
+                onClick={() => setSelectedTopicId(null)}
+                className={cn(
+                  'flex items-center gap-2 mb-6 text-sm transition-colors',
+                  theme === 'dark'
+                    ? 'text-gray-400 hover:text-white'
+                    : 'text-gray-600 hover:text-gray-900'
+                )}
+              >
+                <ArrowLeft className="w-4 h-4" />
+                {isZh ? '返回问题列表' : 'Back to questions'}
+              </button>
+
+              {selectedTopic && (
+                <div className="space-y-6">
+                  {/* 主题标题 */}
+                  <div className={cn(
+                    'p-6 rounded-2xl',
+                    theme === 'dark' ? 'bg-slate-800' : 'bg-white shadow-sm'
+                  )}>
+                    <div className="flex items-start gap-4">
+                      <span className="text-4xl">{selectedTopic.emoji}</span>
+                      <div className="flex-1">
+                        <h2 className={cn(
+                          'text-xl font-bold mb-2',
+                          theme === 'dark' ? 'text-white' : 'text-gray-900'
+                        )}>
+                          {isZh ? selectedTopic.question.zh : selectedTopic.question.en}
+                        </h2>
+                        <p className={cn(
+                          'text-sm',
+                          theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
+                        )}>
+                          {isZh ? selectedTopic.teaser.zh : selectedTopic.teaser.en}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* 动手试试 - 核心互动 */}
+                  {selectedTopic.quickDemo && (
+                    <MiniDemoCard
+                      demoId={selectedTopic.quickDemo}
+                      topic={selectedTopic}
+                      onExpand={() => navigate(`/demos/${selectedTopic.quickDemo}`)}
+                    />
+                  )}
+
+                  {/* Stop & Think 检查点 */}
+                  <StopAndThink
+                    question={{
+                      en: `Before diving deeper: What do you think is happening here? Why might ${selectedTopic.question.en.toLowerCase().replace('?', '')}?`,
+                      zh: `在深入之前：你觉得这里发生了什么？为什么${selectedTopic.question.zh.replace('？', '')}？`
+                    }}
+                    hint={{
+                      en: 'Think about what makes polarized light special compared to ordinary light.',
+                      zh: '想想偏振光和普通光相比有什么特别之处。'
+                    }}
+                    onComplete={() => handleCheckpointComplete(`${selectedTopic.id}-think`)}
+                    isCompleted={completedCheckpoints.includes(`${selectedTopic.id}-think`)}
+                  />
+
+                  {/* 深入内容 - 根据深度级别显示 */}
+                  <div className={cn(
+                    'p-5 rounded-xl border',
+                    theme === 'dark'
+                      ? 'bg-slate-800/50 border-slate-700'
+                      : 'bg-white border-gray-200'
+                  )}>
+                    <div className="flex items-center justify-between mb-4">
+                      <h3 className={cn(
+                        'font-medium flex items-center gap-2',
+                        theme === 'dark' ? 'text-white' : 'text-gray-900'
+                      )}>
+                        <BookOpen className="w-4 h-4" />
+                        {isZh ? '了解更多' : 'Learn More'}
+                      </h3>
+                      <DepthControls
+                        currentDepth={depthLevel}
+                        onDepthChange={setDepthLevel}
+                      />
+                    </div>
+
+                    {/* 根据深度显示不同内容 */}
+                    <div className={cn(
+                      'text-sm leading-relaxed',
+                      theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+                    )}>
+                      {depthLevel === 'simple' && (
+                        <p>
+                          {isZh
+                            ? '偏振光就像只在一个方向振动的波。普通光在所有方向振动，但偏振滤镜只让特定方向的振动通过。就像栅栏只让特定方向的绳波通过一样。'
+                            : 'Polarized light is like a wave that only vibrates in one direction. Regular light vibrates in all directions, but a polarizing filter only lets vibrations in a specific direction pass through. It\'s like a fence that only allows rope waves in a specific orientation to pass.'}
+                        </p>
+                      )}
+                      {depthLevel === 'formulas' && (
+                        <div className="space-y-3">
+                          <p>
+                            {isZh
+                              ? '当偏振光通过偏振片时，透射强度遵循马吕斯定律：'
+                              : 'When polarized light passes through a polarizer, the transmitted intensity follows Malus\'s Law:'}
+                          </p>
+                          <div className={cn(
+                            'p-3 rounded-lg font-mono text-center',
+                            theme === 'dark' ? 'bg-slate-900' : 'bg-gray-100'
+                          )}>
+                            I = I₀ cos²(θ)
+                          </div>
+                          <p className="text-xs text-gray-500">
+                            {isZh
+                              ? '其中 θ 是光的偏振方向和偏振片透光轴的夹角'
+                              : 'Where θ is the angle between the light\'s polarization and the polarizer\'s axis'}
+                          </p>
+                        </div>
+                      )}
+                      {depthLevel === 'theory' && (
+                        <div className="space-y-3">
+                          <p>
+                            {isZh
+                              ? '从电磁波理论角度，偏振描述的是电场矢量 E 的振动方向。对于平面单色波，电场可以表示为 Jones 矢量的形式。'
+                              : 'From electromagnetic theory, polarization describes the oscillation direction of the electric field vector E. For plane monochromatic waves, the electric field can be represented as a Jones vector.'}
+                          </p>
+                          <div className={cn(
+                            'p-3 rounded-lg font-mono text-sm space-y-2',
+                            theme === 'dark' ? 'bg-slate-900' : 'bg-gray-100'
+                          )}>
+                            <div>E = [Ex, Ey]ᵀ exp(i(kz - ωt))</div>
+                            <div className="text-xs opacity-70">
+                              {isZh ? '线偏振: δ = 0 或 π' : 'Linear: δ = 0 or π'}
+                              <br />
+                              {isZh ? '圆偏振: |Ex| = |Ey|, δ = ±π/2' : 'Circular: |Ex| = |Ey|, δ = ±π/2'}
+                            </div>
+                          </div>
+                          <Link
+                            to="/calc/jones"
+                            className="inline-flex items-center gap-1 text-xs text-cyan-500 hover:text-cyan-400"
+                          >
+                            {isZh ? '试试 Jones 计算器' : 'Try the Jones Calculator'} →
+                          </Link>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* 游戏挑战 */}
+                  <div className={cn(
+                    'p-4 rounded-xl flex items-center gap-4',
+                    theme === 'dark'
+                      ? 'bg-pink-500/10 border border-pink-500/20'
+                      : 'bg-pink-50 border border-pink-100'
+                  )}>
+                    <div className="w-10 h-10 rounded-full bg-pink-500 flex items-center justify-center flex-shrink-0">
+                      <Gamepad2 className="w-5 h-5 text-white" />
+                    </div>
+                    <div className="flex-1">
+                      <h4 className={cn(
+                        'font-medium text-sm',
+                        theme === 'dark' ? 'text-pink-300' : 'text-pink-700'
+                      )}>
+                        {isZh ? '准备好挑战了吗？' : 'Ready for a challenge?'}
+                      </h4>
+                      <p className={cn(
+                        'text-xs',
+                        theme === 'dark' ? 'text-pink-400/70' : 'text-pink-600/70'
+                      )}>
+                        {isZh ? '用你学到的知识来解决光学谜题' : 'Use what you learned to solve optical puzzles'}
+                      </p>
+                    </div>
+                    <Link
+                      to="/games/2d"
+                      className="px-4 py-2 rounded-lg bg-pink-500 text-white text-sm font-medium hover:bg-pink-600 transition-colors"
+                    >
+                      {isZh ? '开始' : 'Play'}
+                    </Link>
+                  </div>
+
+                  {/* 相关发现 */}
+                  <RelatedDiscoveries
+                    topics={DISCOVERY_TOPICS}
+                    currentTopicId={selectedTopic.id}
+                    onSelect={setSelectedTopicId}
+                  />
+                </div>
+              )}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
Breaking away from the information-overloaded "Demo Gallery" approach, this redesign introduces a Google Learn About-inspired discovery mode with the following key components:

New Components:
- DiscoveryPage: Question-driven entry point with topic cards
- MicroLearningCard: Bite-sized concept cards with expandable depth
- InteractiveExperimentModule: Narrative-driven hands-on experiments
- GuidedExplorationPath: Linear learning journeys with checkpoints
- StopAndThink: Reflection checkpoints promoting active learning

Design Principles:
- Progressive disclosure: Start with curiosity, reveal depth on demand
- Question-driven entry: "Why does X happen?" instead of topic menus
- Depth controls: Simple/Formulas/Theory toggle for all content
- Active learning: Prediction prompts before revealing answers
- Connected exploration: Related discoveries link topics together

The new /discover route provides an alternative to /demos that avoids overwhelming users with 20+ demos and extensive information cards.

Routes added:
- /discover - New discovery homepage
- /discover/:topicId - Topic detail view