### PR TITLE
Enhance color display richness for polarization

### DIFF
--- a/src/components/game/LightBeams.tsx
+++ b/src/components/game/LightBeams.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useMemo } from 'react'
 import * as THREE from 'three'
 import { Line } from '@react-three/drei'
 import { World } from '@/core/World'
-import { LightState, LightPacket, BlockPosition, POLARIZATION_COLORS, DIRECTION_VECTORS } from '@/core/types'
+import { LightState, LightPacket, BlockPosition, DIRECTION_VECTORS, getPolarizationColorNumeric } from '@/core/types'
 import { VisionMode } from '@/stores/gameStore'
 
 interface LightBeamsProps {
@@ -72,7 +72,8 @@ function LightPacketBeam({ position, packet, visionMode }: LightPacketBeamProps)
 
   const color = useMemo(() => {
     if (visionMode === 'polarized') {
-      return POLARIZATION_COLORS[packet.polarization as keyof typeof POLARIZATION_COLORS] || 0xffffaa
+      // 使用连续彩虹色模式，获得更丰富的颜色表现
+      return getPolarizationColorNumeric(packet.polarization)
     }
     return 0xffffaa
   }, [visionMode, packet.polarization])

--- a/src/components/shared/optical/LightBeamSVG.tsx
+++ b/src/components/shared/optical/LightBeamSVG.tsx
@@ -5,15 +5,17 @@
  * 偏振颜色映射说明：
  * 这是一种可视化约定(visualization convention)，而非物理特性。
  * 在现实中，偏振光的颜色由其波长决定，与偏振角度无关。
- * 使用不同颜色区分偏振方向是为了教学可视化目的：
- *   - 0° (水平偏振): 红色 #ff4444
- *   - 45°: 橙色 #ffaa00
- *   - 90° (垂直偏振): 绿色 #44ff44
- *   - 135°: 蓝色 #4444ff
+ * 使用不同颜色区分偏振方向是为了教学可视化目的。
+ *
+ * 支持三种色彩模式（通过 getPolarizationColor 从 lib/polarization 获取）：
+ *   - discrete: 经典4色（0°=红, 45°=橙, 90°=绿, 135°=蓝）
+ *   - continuous: 连续彩虹渐变（角度→色相映射）
+ *   - michelLevy: 米歇尔-莱维干涉色（模拟偏光显微镜）
  *
  * 这种颜色编码参考了偏振显微镜中的惯例，并非通用标准。
  */
 
+import { getPolarizationColor as getDefaultColor } from '@/lib/polarization'
 import type { GetPolarizationColorFn, LightBeamSegment } from './types'
 
 export interface LightBeamSVGProps {
@@ -35,13 +37,8 @@ export function LightBeamSVG({
 }: LightBeamSVGProps) {
   // 偏振角度到颜色的映射函数 - 这是可视化约定，非物理特性
   // 颜色周期为180°，因为偏振方向具有180°对称性
-  const getColor = getPolarizationColor || ((angle: number) => {
-    const normalizedAngle = ((angle % 180) + 180) % 180
-    if (normalizedAngle < 22.5 || normalizedAngle >= 157.5) return '#ff4444'  // 0°附近 - 水平
-    if (normalizedAngle < 67.5) return '#ffaa00'  // 45°附近
-    if (normalizedAngle < 112.5) return '#44ff44' // 90°附近 - 垂直
-    return '#4444ff' // 135°附近
-  })
+  // 使用集中管理的色彩函数，支持三种模式：discrete/continuous/michelLevy
+  const getColor = getPolarizationColor || getDefaultColor
 
   const opacity = Math.max(0.2, beam.intensity / 100)
   const strokeWidth = Math.max(0.5, (beam.intensity / 100) * 2)

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -101,13 +101,49 @@ export const OPPOSITE_DIRECTION: Record<Direction, Direction> = {
   down: 'up'
 };
 
-// 偏振角度对应的颜色（用于可视化）
+// 偏振角度对应的颜色（用于可视化）- 离散模式（Three.js数值格式）
 export const POLARIZATION_COLORS: Record<PolarizationAngle, number> = {
   0: 0xff4444,    // 红色 - 水平
   45: 0xffaa00,   // 橙黄色 - 45度
   90: 0x44ff44,   // 绿色 - 垂直
   135: 0x4444ff   // 蓝色 - 135度
 };
+
+/**
+ * 将十六进制颜色字符串转换为Three.js数值格式
+ * @param hexString 如 '#ff4444'
+ * @returns 数值如 0xff4444
+ */
+export function hexStringToNumber(hexString: string): number {
+  return parseInt(hexString.replace('#', ''), 16);
+}
+
+/**
+ * HSL转Three.js数值颜色（连续彩虹模式）
+ * @param angle 偏振角度 (0-180)
+ * @returns Three.js数值颜色
+ */
+export function getPolarizationColorNumeric(angle: number): number {
+  // 归一化角度到 0-180
+  const normalizedAngle = ((angle % 180) + 180) % 180;
+  // 映射到HSL色相 (0-360)
+  const hue = (normalizedAngle * 2) % 360;
+
+  // HSL to RGB conversion (s=0.85, l=0.55)
+  const s = 0.85;
+  const l = 0.55;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: number) => {
+    const k = (n + hue / 30) % 12;
+    return l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+  };
+
+  const r = Math.round(255 * f(0));
+  const g = Math.round(255 * f(8));
+  const b = Math.round(255 * f(4));
+
+  return (r << 16) | (g << 8) | b;
+}
 
 // 默认方块状态
 export function createDefaultBlockState(type: BlockType): BlockState {

--- a/src/lib/polarization.ts
+++ b/src/lib/polarization.ts
@@ -1,9 +1,43 @@
 /**
  * Polarization utilities - 偏振光色彩和角度处理工具库
  * 可在2D游戏、3D游戏和课程Demo中复用
+ *
+ * 支持三种色彩模式：
+ * - discrete: 离散4色模式（经典教学配色）
+ * - continuous: 连续HSL渐变（彩虹色）
+ * - michelLevy: 米歇尔-莱维干涉色（模拟真实偏光显微镜）
  */
 
 import type { PolarizationAngle } from '@/core/types'
+
+// ============== 色彩模式定义 ==============
+
+/**
+ * 偏振色彩显示模式
+ * - discrete: 离散4色（教学经典配色，便于区分）
+ * - continuous: 连续彩虹色（HSL色相映射，更丰富）
+ * - michelLevy: 米歇尔-莱维干涉色（模拟真实偏光显微镜观察效果）
+ */
+export type PolarizationColorMode = 'discrete' | 'continuous' | 'michelLevy'
+
+// 当前全局色彩模式
+let currentColorMode: PolarizationColorMode = 'continuous'
+
+/**
+ * 设置偏振色彩显示模式
+ */
+export function setColorMode(mode: PolarizationColorMode): void {
+  currentColorMode = mode
+}
+
+/**
+ * 获取当前色彩模式
+ */
+export function getColorMode(): PolarizationColorMode {
+  return currentColorMode
+}
+
+// ============== 离散色彩定义（经典模式）==============
 
 // 偏振角度对应的十六进制颜色
 export const POLARIZATION_HEX_COLORS: Record<PolarizationAngle, string> = {
@@ -35,7 +69,7 @@ const ANGLE_BOUNDARIES = {
  * @param angle 偏振角度 (任意数值，会被归一化到0-180)
  * @returns 十六进制颜色字符串
  */
-export function getPolarizationColor(angle: number): string {
+export function getPolarizationColorDiscrete(angle: number): string {
   const normalizedAngle = normalizeAngle(angle)
 
   if (normalizedAngle < ANGLE_BOUNDARIES.RED_MAX || normalizedAngle >= ANGLE_BOUNDARIES.BLUE_MAX) {
@@ -48,6 +82,186 @@ export function getPolarizationColor(angle: number): string {
     return POLARIZATION_HEX_COLORS[90]
   }
   return POLARIZATION_HEX_COLORS[135]
+}
+
+// ============== 连续彩虹色模式 ==============
+
+/**
+ * HSL 转 Hex 颜色
+ * @param h 色相 (0-360)
+ * @param s 饱和度 (0-100)
+ * @param l 亮度 (0-100)
+ */
+function hslToHex(h: number, s: number, l: number): string {
+  s /= 100
+  l /= 100
+  const a = s * Math.min(l, 1 - l)
+  const f = (n: number) => {
+    const k = (n + h / 30) % 12
+    const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1)
+    return Math.round(255 * color).toString(16).padStart(2, '0')
+  }
+  return `#${f(0)}${f(8)}${f(4)}`
+}
+
+/**
+ * 连续彩虹色模式 - 将偏振角度映射到HSL色相
+ * 0° → 红色 (hue=0)
+ * 45° → 橙黄色 (hue=45)
+ * 90° → 青绿色 (hue=150)
+ * 135° → 蓝紫色 (hue=270)
+ * 180° → 回到红色
+ *
+ * @param angle 偏振角度
+ * @param saturation 饱和度 (0-100)，默认85
+ * @param lightness 亮度 (0-100)，默认55
+ */
+export function getPolarizationColorContinuous(
+  angle: number,
+  saturation: number = 85,
+  lightness: number = 55
+): string {
+  const normalizedAngle = normalizeAngle(angle)
+  // 将0-180度映射到0-360度色相，形成完整彩虹
+  const hue = (normalizedAngle * 2) % 360
+  return hslToHex(hue, saturation, lightness)
+}
+
+// ============== 米歇尔-莱维干涉色模式 ==============
+
+/**
+ * 米歇尔-莱维干涉色表
+ * 模拟偏光显微镜中观察到的干涉色
+ * 这是一个查找表，基于真实的 Michel-Lévy chart
+ *
+ * 颜色顺序遵循第一级干涉序列：
+ * 灰黑 → 灰白 → 黄 → 橙 → 红 → 紫 → 蓝 → 青绿
+ */
+const MICHEL_LEVY_COLORS = [
+  // 第一级干涉色序列 (0-180度映射)
+  { angle: 0, color: '#2a2a2a' },    // 深灰/黑（消光位）
+  { angle: 10, color: '#4a4a4a' },   // 灰
+  { angle: 20, color: '#6a6a6a' },   // 浅灰
+  { angle: 30, color: '#8c8c8c' },   // 灰白
+  { angle: 40, color: '#b8a878' },   // 浅黄
+  { angle: 50, color: '#d4c46c' },   // 黄
+  { angle: 60, color: '#e8b040' },   // 金黄/橙黄
+  { angle: 70, color: '#e89030' },   // 橙
+  { angle: 80, color: '#e85040' },   // 橙红
+  { angle: 90, color: '#d82050' },   // 红
+  { angle: 100, color: '#c02080' },  // 红紫
+  { angle: 110, color: '#9030a0' },  // 紫
+  { angle: 120, color: '#6040c0' },  // 蓝紫
+  { angle: 130, color: '#3050d8' },  // 蓝
+  { angle: 140, color: '#2070e0' },  // 天蓝
+  { angle: 150, color: '#20a0d0' },  // 青蓝
+  { angle: 160, color: '#20b8a0' },  // 青绿
+  { angle: 170, color: '#30c080' },  // 绿
+  { angle: 180, color: '#2a2a2a' },  // 回到深灰（消光位）
+]
+
+/**
+ * 在两个颜色之间进行线性插值
+ */
+function lerpColor(color1: string, color2: string, t: number): string {
+  const r1 = parseInt(color1.slice(1, 3), 16)
+  const g1 = parseInt(color1.slice(3, 5), 16)
+  const b1 = parseInt(color1.slice(5, 7), 16)
+  const r2 = parseInt(color2.slice(1, 3), 16)
+  const g2 = parseInt(color2.slice(3, 5), 16)
+  const b2 = parseInt(color2.slice(5, 7), 16)
+
+  const r = Math.round(r1 + (r2 - r1) * t)
+  const g = Math.round(g1 + (g2 - g1) * t)
+  const b = Math.round(b1 + (b2 - b1) * t)
+
+  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`
+}
+
+/**
+ * 米歇尔-莱维干涉色模式
+ * 模拟偏光显微镜中的干涉色效果
+ * 这是真实偏光显微镜观察双折射材料时看到的颜色序列
+ *
+ * @param angle 偏振角度
+ */
+export function getPolarizationColorMichelLevy(angle: number): string {
+  const normalizedAngle = normalizeAngle(angle)
+
+  // 找到角度所在的区间并进行插值
+  for (let i = 0; i < MICHEL_LEVY_COLORS.length - 1; i++) {
+    const curr = MICHEL_LEVY_COLORS[i]
+    const next = MICHEL_LEVY_COLORS[i + 1]
+    if (normalizedAngle >= curr.angle && normalizedAngle < next.angle) {
+      const t = (normalizedAngle - curr.angle) / (next.angle - curr.angle)
+      return lerpColor(curr.color, next.color, t)
+    }
+  }
+
+  return MICHEL_LEVY_COLORS[0].color
+}
+
+// ============== 统一入口函数 ==============
+
+/**
+ * 根据当前色彩模式获取偏振颜色
+ * 这是推荐使用的统一入口函数
+ *
+ * @param angle 偏振角度
+ * @param mode 可选的色彩模式覆盖（如不提供则使用全局设置）
+ */
+export function getPolarizationColor(angle: number, mode?: PolarizationColorMode): string {
+  const effectiveMode = mode ?? currentColorMode
+
+  switch (effectiveMode) {
+    case 'discrete':
+      return getPolarizationColorDiscrete(angle)
+    case 'continuous':
+      return getPolarizationColorContinuous(angle)
+    case 'michelLevy':
+      return getPolarizationColorMichelLevy(angle)
+    default:
+      return getPolarizationColorContinuous(angle)
+  }
+}
+
+/**
+ * 获取指定角度在各种模式下的颜色预览
+ * 用于UI中展示不同模式的效果
+ */
+export function getColorModePreview(angle: number): Record<PolarizationColorMode, string> {
+  return {
+    discrete: getPolarizationColorDiscrete(angle),
+    continuous: getPolarizationColorContinuous(angle),
+    michelLevy: getPolarizationColorMichelLevy(angle),
+  }
+}
+
+/**
+ * 色彩模式的显示名称
+ */
+export const COLOR_MODE_NAMES: Record<PolarizationColorMode, { en: string; zh: string }> = {
+  discrete: { en: 'Classic 4-Color', zh: '经典四色' },
+  continuous: { en: 'Rainbow Gradient', zh: '彩虹渐变' },
+  michelLevy: { en: 'Michel-Lévy Chart', zh: '米歇尔-莱维干涉色' },
+}
+
+/**
+ * 色彩模式的描述
+ */
+export const COLOR_MODE_DESCRIPTIONS: Record<PolarizationColorMode, { en: string; zh: string }> = {
+  discrete: {
+    en: 'Traditional 4-color scheme (0°=Red, 45°=Orange, 90°=Green, 135°=Blue)',
+    zh: '传统四色方案（0°=红，45°=橙，90°=绿，135°=蓝）',
+  },
+  continuous: {
+    en: 'Smooth rainbow gradient mapping angle to hue for rich color variation',
+    zh: '平滑彩虹渐变，角度映射到色相，颜色变化丰富',
+  },
+  michelLevy: {
+    en: 'Simulates interference colors seen in polarization microscopy',
+    zh: '模拟偏光显微镜中观察到的干涉色序列',
+  },
 }
 
 /**

--- a/src/pages/Game2DPage.tsx
+++ b/src/pages/Game2DPage.tsx
@@ -40,7 +40,14 @@ import { PersistentHeader } from '@/components/shared/PersistentHeader'
 import { SEO } from '@/components/shared/SEO'
 
 // Import shared modules
-import { getPolarizationColor, POLARIZATION_DISPLAY_CONFIG } from '@/lib/polarization'
+import {
+  getPolarizationColor,
+  POLARIZATION_DISPLAY_CONFIG,
+  setColorMode,
+  getColorMode,
+  COLOR_MODE_NAMES,
+  type PolarizationColorMode,
+} from '@/lib/polarization'
 import {
   EmitterSVG,
   PolarizerSVG,
@@ -487,7 +494,14 @@ export function Game2DPage() {
   const [showHint, setShowHint] = useState(false)
   const [isAnimating, setIsAnimating] = useState(true)
   const [showPolarization, setShowPolarization] = useState(true)
+  const [colorMode, setColorModeState] = useState<PolarizationColorMode>(getColorMode())
   const [showMobileInfo, setShowMobileInfo] = useState(false)
+
+  // Handle color mode change
+  const handleColorModeChange = useCallback((mode: PolarizationColorMode) => {
+    setColorMode(mode)
+    setColorModeState(mode)
+  }, [])
 
   // Undo/Redo history state
   const [history, setHistory] = useState<Record<string, Partial<OpticalComponent>>[]>([])
@@ -1104,6 +1118,34 @@ export function Game2DPage() {
                 <Eye className="w-3 h-3" />
                 {isZh ? '偏振色' : 'Polarization'}
               </button>
+
+              {/* Color mode selector */}
+              {showPolarization && (
+                <div className={cn(
+                  'flex flex-col gap-1 px-2 py-1.5 rounded-lg',
+                  isDark ? 'bg-slate-800/90' : 'bg-white/90'
+                )}>
+                  <span className={cn('text-[10px] font-medium mb-0.5', isDark ? 'text-slate-400' : 'text-slate-500')}>
+                    {isZh ? '色彩模式' : 'Color Mode'}
+                  </span>
+                  {(['discrete', 'continuous', 'michelLevy'] as PolarizationColorMode[]).map((mode) => (
+                    <button
+                      key={mode}
+                      onClick={() => handleColorModeChange(mode)}
+                      className={cn(
+                        'px-2 py-0.5 rounded text-[10px] text-left transition-all',
+                        colorMode === mode
+                          ? 'bg-cyan-500/30 text-cyan-400 border border-cyan-500/40'
+                          : isDark
+                            ? 'hover:bg-slate-700 text-slate-400'
+                            : 'hover:bg-slate-100 text-slate-600'
+                      )}
+                    >
+                      {COLOR_MODE_NAMES[mode][isZh ? 'zh' : 'en']}
+                    </button>
+                  ))}
+                </div>
+              )}
             </div>
 
             {/* Sensors status */}


### PR DESCRIPTION
…évy)

- Add three color modes: discrete (classic 4-color), continuous (HSL rainbow), Michel-Lévy (interference colors)
- Default to continuous rainbow mode for richer color visualization
- Add color mode selector UI in 2D game page
- Update LightBeamSVG to use centralized color functions
- Update 3D LightBeams.tsx to use continuous colors
- Add utility functions: getPolarizationColorContinuous, getPolarizationColorMichelLevy
- Add color mode names and descriptions in both English and Chinese