### PR TITLE
Redesign homepage learning and course sections

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -188,9 +188,13 @@
     },
     "startStage": "Start This Stage",
     "startLearning": "Start Learning",
+    "tryNow": "Try Now",
+    "continueLearning": "Continue Learning",
     "explore": "Explore Freely",
     "viewCourse": "View Course",
+    "courseSyllabus": "Course Syllabus",
     "learningJourney": "Learning Journey",
+    "viewAll": "View All",
     "quickAccess": "Quick Access",
     "quick": {
       "games": "Games",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -188,9 +188,13 @@
     },
     "startStage": "开始学习本阶段",
     "startLearning": "开始学习",
+    "tryNow": "立即体验",
+    "continueLearning": "继续学习",
     "explore": "自由探索",
     "viewCourse": "查看课程",
+    "courseSyllabus": "课程大纲",
     "learningJourney": "学习路径",
+    "viewAll": "查看全部",
     "quickAccess": "快捷入口",
     "quick": {
       "games": "游戏",

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -15,7 +15,6 @@ import { PolarWorldLogo } from '@/components/icons'
 import { PolarizedLightHero } from '@/components/effects'
 import { useCourseProgress } from '@/hooks'
 import {
-  ChevronRight,
   Play,
   Lightbulb,
   BookOpen,
@@ -147,18 +146,14 @@ function PolarizationBackground({ theme }: { theme: 'dark' | 'light' }) {
   )
 }
 
-// Learning Stage Card Component
+// Learning Stage Card Component - 简化版，点击跳转到课程页
 function LearningStageCard({
   stage,
   theme,
-  isExpanded,
-  onToggle,
   completedDemos,
 }: {
   stage: LearningStage
   theme: 'dark' | 'light'
-  isExpanded: boolean
-  onToggle: () => void
   completedDemos: string[]
 }) {
   const { t } = useTranslation()
@@ -169,215 +164,81 @@ function LearningStageCard({
   const progressPercent = totalDemos > 0 ? Math.round((completedCount / totalDemos) * 100) : 0
 
   return (
-    <div
-      className={`rounded-2xl border-2 transition-all duration-300 overflow-hidden ${
+    <Link
+      to={`/course?stage=${stage.id}`}
+      className={`group block rounded-xl border transition-all duration-300 hover:-translate-y-1 ${
         theme === 'dark'
-          ? 'bg-slate-800/60 border-slate-700/50 hover:border-slate-600'
+          ? 'bg-slate-800/60 border-slate-700/50 hover:border-slate-500'
           : 'bg-white/80 border-gray-200 hover:border-gray-300'
       }`}
       style={{
-        borderColor: isExpanded ? stage.color : undefined,
-        boxShadow: isExpanded ? `0 0 40px ${stage.color}20` : undefined,
+        boxShadow: `0 4px 20px ${stage.color}10`,
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.borderColor = stage.color
+        e.currentTarget.style.boxShadow = `0 8px 30px ${stage.color}25`
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.borderColor = ''
+        e.currentTarget.style.boxShadow = `0 4px 20px ${stage.color}10`
       }}
     >
-      {/* Stage header */}
-      <div
-        className={`p-5 cursor-pointer transition-all ${
-          theme === 'dark' ? 'hover:bg-slate-700/30' : 'hover:bg-gray-50'
-        }`}
-        onClick={onToggle}
-      >
-        <div className="flex items-start gap-4">
+      <div className="p-4">
+        <div className="flex items-center gap-3">
           {/* Phase number badge */}
           <div
-            className={`flex-shrink-0 w-14 h-14 rounded-2xl flex flex-col items-center justify-center bg-gradient-to-br ${stage.gradient} shadow-lg`}
+            className={`flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center bg-gradient-to-br ${stage.gradient} shadow-md`}
           >
-            <span className="text-white text-xs font-medium opacity-80">{t('home.phase')}</span>
-            <span className="text-white text-xl font-bold">{stage.phase}</span>
+            <span className="text-white text-lg font-bold">{stage.phase}</span>
           </div>
 
           {/* Stage info */}
           <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <h3 className={`text-lg font-bold ${
+            <div className="flex items-center gap-2">
+              <h3 className={`text-sm font-bold truncate ${
                 theme === 'dark' ? 'text-white' : 'text-gray-900'
               }`}>
                 {t(stage.titleKey)}
               </h3>
               {stage.isAdvanced && (
-                <span className={`text-[10px] px-2 py-0.5 rounded-full font-medium ${
+                <span className={`text-[9px] px-1.5 py-0.5 rounded-full font-medium flex-shrink-0 ${
                   theme === 'dark'
-                    ? 'bg-violet-500/20 text-violet-400 border border-violet-500/30'
-                    : 'bg-violet-100 text-violet-700 border border-violet-200'
+                    ? 'bg-violet-500/20 text-violet-400'
+                    : 'bg-violet-100 text-violet-700'
                 }`}>
                   {t('home.advanced')}
                 </span>
               )}
             </div>
-            <p className={`text-sm ${theme === 'dark' ? 'text-gray-400' : 'text-gray-500'}`}>
+            <p className={`text-xs mt-0.5 truncate ${theme === 'dark' ? 'text-gray-400' : 'text-gray-500'}`}>
               {t(stage.subtitleKey)}
             </p>
-            {/* Core question */}
-            <p className={`text-sm mt-2 italic ${
-              theme === 'dark' ? 'text-cyan-400' : 'text-cyan-600'
-            }`}>
-              "{t(stage.questionKey)}"
-            </p>
-
-            {/* Progress bar */}
-            <div className="mt-3 flex items-center gap-3">
-              <div className={`flex-1 h-1.5 rounded-full ${
-                theme === 'dark' ? 'bg-slate-700' : 'bg-gray-200'
-              }`}>
-                <div
-                  className={`h-full rounded-full bg-gradient-to-r ${stage.gradient} transition-all duration-500`}
-                  style={{ width: `${progressPercent}%` }}
-                />
-              </div>
-              <span className={`text-xs font-medium ${
-                theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
-              }`}>
-                {completedCount}/{totalDemos}
-              </span>
-            </div>
           </div>
 
-          {/* Expand indicator */}
-          <ChevronRight
-            className={`w-5 h-5 transition-transform flex-shrink-0 mt-2 ${
-              isExpanded ? 'rotate-90' : ''
-            } ${theme === 'dark' ? 'text-gray-400' : 'text-gray-500'}`}
-          />
+          {/* Arrow */}
+          <ArrowRight className={`w-4 h-4 flex-shrink-0 transition-transform group-hover:translate-x-1 ${
+            theme === 'dark' ? 'text-gray-500 group-hover:text-white' : 'text-gray-400 group-hover:text-gray-700'
+          }`} />
+        </div>
+
+        {/* Progress bar */}
+        <div className="mt-3 flex items-center gap-2">
+          <div className={`flex-1 h-1 rounded-full ${
+            theme === 'dark' ? 'bg-slate-700' : 'bg-gray-200'
+          }`}>
+            <div
+              className={`h-full rounded-full bg-gradient-to-r ${stage.gradient} transition-all duration-500`}
+              style={{ width: `${progressPercent}%` }}
+            />
+          </div>
+          <span className={`text-[10px] font-medium ${
+            theme === 'dark' ? 'text-gray-500' : 'text-gray-400'
+          }`}>
+            {completedCount}/{totalDemos}
+          </span>
         </div>
       </div>
-
-      {/* Expanded content */}
-      {isExpanded && (
-        <div className={`px-5 pb-5 border-t ${
-          theme === 'dark' ? 'border-slate-700/50' : 'border-gray-100'
-        }`}>
-          {/* Demos section */}
-          <div className="mt-4">
-            <h4 className={`text-xs font-semibold uppercase tracking-wider mb-3 flex items-center gap-2 ${
-              theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
-            }`}>
-              <FlaskConical className="w-3.5 h-3.5" />
-              {t('home.resources.demos')}
-            </h4>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-              {stage.demos.map((demo) => (
-                <Link
-                  key={demo.id}
-                  to={demo.link}
-                  className={`group flex items-center gap-3 p-3 rounded-xl transition-all hover:-translate-y-0.5 ${
-                    completedDemos.includes(demo.id)
-                      ? theme === 'dark'
-                        ? 'bg-green-900/20 border border-green-500/30'
-                        : 'bg-green-50 border border-green-200'
-                      : theme === 'dark'
-                        ? 'bg-slate-700/50 border border-slate-600/50 hover:border-cyan-500/50'
-                        : 'bg-gray-50 border border-gray-200 hover:border-cyan-300'
-                  }`}
-                >
-                  <div
-                    className={`w-8 h-8 rounded-lg flex items-center justify-center ${
-                      completedDemos.includes(demo.id)
-                        ? 'bg-green-500/20'
-                        : `bg-gradient-to-br ${stage.gradient} bg-opacity-20`
-                    }`}
-                    style={{ backgroundColor: completedDemos.includes(demo.id) ? undefined : `${stage.color}20` }}
-                  >
-                    {completedDemos.includes(demo.id) ? (
-                      <svg className="w-4 h-4 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                      </svg>
-                    ) : (
-                      <Eye className="w-4 h-4" style={{ color: stage.color }} />
-                    )}
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p className={`text-sm font-medium truncate ${
-                      theme === 'dark' ? 'text-white' : 'text-gray-900'
-                    }`}>
-                      {t(demo.titleKey)}
-                    </p>
-                  </div>
-                  <ArrowRight className={`w-4 h-4 opacity-0 group-hover:opacity-100 transition-opacity ${
-                    theme === 'dark' ? 'text-cyan-400' : 'text-cyan-600'
-                  }`} />
-                </Link>
-              ))}
-            </div>
-          </div>
-
-          {/* Games section - temporarily hidden
-          {stage.games && stage.games.length > 0 && (
-            <div className="mt-4">
-              <h4 className={`text-xs font-semibold uppercase tracking-wider mb-3 flex items-center gap-2 ${
-                theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
-              }`}>
-                <Gamepad2 className="w-3.5 h-3.5" />
-                {t('home.resources.games')}
-              </h4>
-              <div className="flex flex-wrap gap-2">
-                {stage.games.map((game, idx) => (
-                  <Link
-                    key={idx}
-                    to={game.link}
-                    className={`px-3 py-2 rounded-lg text-sm font-medium transition-all hover:scale-105 ${
-                      theme === 'dark'
-                        ? 'bg-pink-900/30 text-pink-400 hover:bg-pink-900/50'
-                        : 'bg-pink-50 text-pink-700 hover:bg-pink-100'
-                    }`}
-                  >
-                    {t(game.titleKey)}
-                  </Link>
-                ))}
-              </div>
-            </div>
-          )}
-          */}
-
-          {/* Tools section */}
-          {stage.tools && stage.tools.length > 0 && (
-            <div className="mt-4">
-              <h4 className={`text-xs font-semibold uppercase tracking-wider mb-3 flex items-center gap-2 ${
-                theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
-              }`}>
-                <Wrench className="w-3.5 h-3.5" />
-                {t('home.resources.tools')}
-              </h4>
-              <div className="flex flex-wrap gap-2">
-                {stage.tools.map((tool, idx) => (
-                  <Link
-                    key={idx}
-                    to={tool.link}
-                    className={`px-3 py-2 rounded-lg text-sm font-medium transition-all hover:scale-105 ${
-                      theme === 'dark'
-                        ? 'bg-indigo-900/30 text-indigo-400 hover:bg-indigo-900/50'
-                        : 'bg-indigo-50 text-indigo-700 hover:bg-indigo-100'
-                    }`}
-                  >
-                    {t(tool.titleKey)}
-                  </Link>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* CTA Button */}
-          <div className="mt-5">
-            <Link
-              to={stage.demos[0]?.link || '/demos'}
-              className={`inline-flex items-center gap-2 px-5 py-2.5 rounded-full text-sm font-medium transition-all hover:scale-105 bg-gradient-to-r ${stage.gradient} text-white shadow-lg`}
-            >
-              <Play className="w-4 h-4" />
-              {t('home.startStage')}
-            </Link>
-          </div>
-        </div>
-      )}
-    </div>
+    </Link>
   )
 }
 
@@ -716,7 +577,6 @@ export function HomePage() {
   const { theme } = useTheme()
   const navigate = useNavigate()
   const { progress } = useCourseProgress()
-  const [expandedStageId, setExpandedStageId] = useState<string>('stage1')
 
   // Guided start modal state
   const [showGuidedStart, setShowGuidedStart] = useState(() => {
@@ -809,13 +669,28 @@ export function HomePage() {
           <div className="flex flex-wrap justify-center gap-4 mt-6">
             <button
               onClick={() => {
-                const firstDemo = LEARNING_STAGES[0].demos[0]
-                if (firstDemo) navigate(firstDemo.link)
+                // 智能化入口：有进度则继续学习，无进度则显示引导
+                if (progress.completedDemos.length > 0) {
+                  // 找到第一个未完成的 demo
+                  const allDemos = LEARNING_STAGES.flatMap(s => s.demos)
+                  const nextDemo = allDemos.find(d => !progress.completedDemos.includes(d.id))
+                  if (nextDemo) {
+                    navigate(nextDemo.link)
+                  } else {
+                    // 全部完成，去高级内容
+                    navigate('/demos/stokes')
+                  }
+                } else {
+                  // 新用户显示引导选择
+                  setShowGuidedStart(true)
+                }
               }}
               className="px-6 py-3 rounded-full bg-gradient-to-r from-cyan-500 via-blue-500 to-violet-500 text-white font-medium flex items-center gap-2 hover:scale-105 transition-transform shadow-lg shadow-blue-500/25"
             >
               <Play className="w-5 h-5" />
-              {t('home.startLearning')}
+              {progress.completedDemos.length > 0
+                ? t('home.continueLearning')
+                : t('home.tryNow')}
             </button>
             <Link
               to="/course"
@@ -826,12 +701,12 @@ export function HomePage() {
               }`}
             >
               <BookOpen className="w-5 h-5" />
-              {t('home.viewCourse')}
+              {t('home.courseSyllabus')}
             </Link>
           </div>
         </div>
 
-        {/* Learning Journey - Three Stages */}
+        {/* Learning Journey - Three Stages (简化预览，点击进入课程大纲) */}
         <div className="mb-8">
           <div className="flex items-center justify-between mb-4">
             <h2 className={`text-lg font-bold ${
@@ -839,36 +714,26 @@ export function HomePage() {
             }`}>
               {t('home.learningJourney')}
             </h2>
-            <div className={`flex items-center gap-1 px-3 py-1.5 rounded-full ${
-              theme === 'dark' ? 'bg-slate-800' : 'bg-gray-100'
-            }`}>
-              {LEARNING_STAGES.map((stage, idx) => (
-                <button
-                  key={stage.id}
-                  onClick={() => setExpandedStageId(stage.id)}
-                  className={`px-2.5 py-1 rounded-full text-xs font-medium transition-all ${
-                    expandedStageId === stage.id
-                      ? `bg-gradient-to-r ${stage.gradient} text-white`
-                      : theme === 'dark'
-                        ? 'text-gray-400 hover:text-white'
-                        : 'text-gray-500 hover:text-gray-900'
-                  }`}
-                >
-                  {idx + 1}
-                </button>
-              ))}
-            </div>
+            <Link
+              to="/course"
+              className={`text-xs flex items-center gap-1 transition-colors ${
+                theme === 'dark'
+                  ? 'text-cyan-400 hover:text-cyan-300'
+                  : 'text-cyan-600 hover:text-cyan-700'
+              }`}
+            >
+              {t('home.viewAll')}
+              <ArrowRight className="w-3 h-3" />
+            </Link>
           </div>
 
-          {/* Stage Cards */}
-          <div className="space-y-4">
+          {/* Stage Cards - 水平排列的简化卡片 */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             {LEARNING_STAGES.map((stage) => (
               <LearningStageCard
                 key={stage.id}
                 stage={stage}
                 theme={theme}
-                isExpanded={expandedStageId === stage.id}
-                onToggle={() => setExpandedStageId(expandedStageId === stage.id ? '' : stage.id)}
                 completedDemos={progress.completedDemos}
               />
             ))}


### PR DESCRIPTION
- Change "开始学习" to smart entry: "立即体验" (new users) / "继续学习" (returning users)
- Change "查看课程" to "课程大纲" for clearer positioning
- Simplify learning stages display on homepage (compact cards linking to course page)
- Remove redundant expanded content that duplicated course page
- Add translations for tryNow, continueLearning, courseSyllabus, viewAll