### PR TITLE
Redesign homepage with course outline structure

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -230,6 +230,123 @@
       "screenPolarizer": "Screen + Polarizer",
       "screenPolarizerDesc": "Rotate a polarizer over screen"
     },
+    "keyExperiment": "Key Experiment",
+    "resType": {
+      "demo": "Demo",
+      "experiment": "Exp",
+      "history": "History",
+      "game": "Game",
+      "tool": "Tool"
+    },
+    "res": {
+      "lightWave": "Light Wave",
+      "polarIntro": "Polarization Intro",
+      "birefringence": "Birefringence",
+      "calciteHistory": "Discovery of Calcite",
+      "malus": "Malus's Law",
+      "malusExp": "Malus Experiment",
+      "malusHistory": "Malus's Story",
+      "gameLevel0": "Tutorial Level",
+      "fresnel": "Fresnel Equations",
+      "brewster": "Brewster's Angle",
+      "brewsterExp": "Reflection Experiment",
+      "chromatic": "Chromatic Polarization",
+      "anisotropy": "Stress Birefringence",
+      "stressExp": "Stress Analysis",
+      "opticalRotation": "Optical Rotation",
+      "sugarExp": "Sugar Rainbow",
+      "rayleigh": "Rayleigh Scattering",
+      "mie": "Mie Scattering",
+      "monteCarlo": "Monte Carlo",
+      "stokes": "Stokes Vector",
+      "mueller": "Mueller Matrix",
+      "stokesCalc": "Stokes Calculator",
+      "muellerCalc": "Mueller Calculator",
+      "jones": "Jones Matrix",
+      "jonesCalc": "Jones Calculator",
+      "poincare": "Poincare Sphere",
+      "microscopy": "Polarimetric Microscopy"
+    },
+    "units": {
+      "unit1": {
+        "title": "Polarization States & Measurement",
+        "subtitle": "From Calcite to Malus's Law",
+        "description": "Starting from Bartholin's discovery of calcite double images in 1669, explore the basics of light polarization, polarizing devices, and polarization measurement.",
+        "keyExp": "Calcite Birefringence",
+        "s1": {
+          "title": "Light Fundamentals",
+          "desc": "Transverse waves and refraction"
+        },
+        "s2": {
+          "title": "Calcite & Birefringence",
+          "desc": "o-ray, e-ray and index ellipsoid"
+        },
+        "s3": {
+          "title": "Polarizers & Malus's Law",
+          "desc": "Polarizing devices and measurement"
+        }
+      },
+      "unit2": {
+        "title": "Interface Reflection Polarization",
+        "subtitle": "Fresnel Equations & Brewster's Angle",
+        "description": "Learn how s-polarized and p-polarized light behave differently at interfaces, understand Fresnel equations and Brewster's angle.",
+        "keyExp": "Brewster Angle Measurement",
+        "s1": {
+          "title": "Fresnel Equations",
+          "desc": "Quantitative reflection calculation"
+        },
+        "s2": {
+          "title": "Brewster's Angle",
+          "desc": "Zero p-polarized reflection"
+        }
+      },
+      "unit3": {
+        "title": "Transparent Media Polarization",
+        "subtitle": "Chromatic Polarization & Optical Rotation",
+        "description": "Explore birefringence and optical rotation in transparent media, understand stress analysis and concentration measurement applications.",
+        "keyExp": "Chromatic Polarization & Stress",
+        "s1": {
+          "title": "Chromatic Polarization",
+          "desc": "Birefringence modulation and colors"
+        },
+        "s2": {
+          "title": "Optical Rotation",
+          "desc": "Molecular chirality and rotation"
+        }
+      },
+      "unit4": {
+        "title": "Turbid Media Polarization",
+        "subtitle": "Scattering from Blue Sky to White Clouds",
+        "description": "Understand spectral and polarization features of particle scattering, explain natural phenomena like blue sky and red sunset, learn Monte Carlo simulation.",
+        "keyExp": "Simulating Blue Sky",
+        "s1": {
+          "title": "Scattering Spectral Features",
+          "desc": "Rayleigh and Mie scattering"
+        },
+        "s2": {
+          "title": "Scattering Polarization Features",
+          "desc": "Angle vs polarization degree"
+        }
+      },
+      "unit5": {
+        "title": "Full Polarimetric Techniques",
+        "subtitle": "Stokes, Mueller & Frontier Applications",
+        "description": "Learn complete mathematical tools for polarization description, explore full polarimetric imaging in ocean, biomedical, and materials applications.",
+        "keyExp": "Mueller Matrix Imaging",
+        "s1": {
+          "title": "Complete Polarization Description",
+          "desc": "Stokes vector and Mueller matrix"
+        },
+        "s2": {
+          "title": "Jones Matrix & Poincare Sphere",
+          "desc": "Geometric representation"
+        },
+        "s3": {
+          "title": "Full Polarimetric Imaging",
+          "desc": "Polarimetric microscopy & imaging"
+        }
+      }
+    },
     "courseOutline": {
       "title": "Course Outline",
       "badge": "PSRT Course",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -230,6 +230,123 @@
       "screenPolarizer": "屏幕+偏振片",
       "screenPolarizerDesc": "在屏幕前旋转偏振片"
     },
+    "keyExperiment": "核心实验",
+    "resType": {
+      "demo": "演示",
+      "experiment": "实验",
+      "history": "历史",
+      "game": "游戏",
+      "tool": "工具"
+    },
+    "res": {
+      "lightWave": "光波演示",
+      "polarIntro": "偏振入门",
+      "birefringence": "双折射",
+      "calciteHistory": "冰洲石的发现",
+      "malus": "马吕斯定律",
+      "malusExp": "马吕斯实验",
+      "malusHistory": "马吕斯的故事",
+      "gameLevel0": "入门关卡",
+      "fresnel": "菲涅尔公式",
+      "brewster": "布儒斯特角",
+      "brewsterExp": "反射偏振实验",
+      "chromatic": "色偏振",
+      "anisotropy": "应力双折射",
+      "stressExp": "色偏振实验",
+      "opticalRotation": "旋光现象",
+      "sugarExp": "糖水彩虹实验",
+      "rayleigh": "瑞利散射",
+      "mie": "米氏散射",
+      "monteCarlo": "蒙特卡洛模拟",
+      "stokes": "Stokes矢量",
+      "mueller": "Mueller矩阵",
+      "stokesCalc": "Stokes计算器",
+      "muellerCalc": "Mueller计算器",
+      "jones": "Jones矩阵",
+      "jonesCalc": "Jones计算器",
+      "poincare": "庞加莱球",
+      "microscopy": "偏振显微镜"
+    },
+    "units": {
+      "unit1": {
+        "title": "光的偏振态及其调制和测量",
+        "subtitle": "从冰洲石到马吕斯定律",
+        "description": "从1669年巴多林发现冰洲石双像开始，探索光的偏振性质、偏振器件和偏振态测量的基础知识。",
+        "keyExp": "冰洲石双折射实验",
+        "s1": {
+          "title": "光的基本特征",
+          "desc": "横波概念和光的折射"
+        },
+        "s2": {
+          "title": "冰洲石与双折射",
+          "desc": "o光、e光与折射率椭球"
+        },
+        "s3": {
+          "title": "偏振器件与马吕斯定律",
+          "desc": "起偏/检偏器件和偏振态测量"
+        }
+      },
+      "unit2": {
+        "title": "界面反射的偏振特征",
+        "subtitle": "菲涅尔公式与布儒斯特角",
+        "description": "学习界面反射时s偏振和p偏振的不同行为，理解菲涅尔公式和布儒斯特角的物理意义与应用。",
+        "keyExp": "布儒斯特角测量实验",
+        "s1": {
+          "title": "菲涅尔公式",
+          "desc": "垂直和平行入射面反射光的定量计算"
+        },
+        "s2": {
+          "title": "布儒斯特角",
+          "desc": "平行入射面光反射为零的特殊角度"
+        }
+      },
+      "unit3": {
+        "title": "透明介质的偏振特征",
+        "subtitle": "色偏振与旋光效应",
+        "description": "探索透明介质的双折射和旋光性，理解应力分析、糖浓度测量等实际应用背后的物理原理。",
+        "keyExp": "色偏振与应力分析实验",
+        "s1": {
+          "title": "色偏振",
+          "desc": "双折射对线偏振光的调制及颜色产生"
+        },
+        "s2": {
+          "title": "旋光",
+          "desc": "糖分子手性与偏振面旋转"
+        }
+      },
+      "unit4": {
+        "title": "浑浊介质的偏振特征",
+        "subtitle": "从蓝天到白云的散射偏振",
+        "description": "了解颗粒物散射的光谱和偏振特征，解释蓝天、红霞、白云等自然现象，学习蒙特卡洛光子模拟。",
+        "keyExp": "纳米微球模拟蓝天实验",
+        "s1": {
+          "title": "颗粒物散射的光谱特征",
+          "desc": "瑞利散射与米氏散射"
+        },
+        "s2": {
+          "title": "颗粒物散射的偏振特征",
+          "desc": "散射角度与偏振度的关系"
+        }
+      },
+      "unit5": {
+        "title": "全偏振光学技术",
+        "subtitle": "Stokes、Mueller与前沿应用",
+        "description": "学习完整描述偏振态和偏振变换的数学工具，了解全偏振成像在海洋、生医、材料等领域的前沿应用。",
+        "keyExp": "Mueller矩阵成像演示",
+        "s1": {
+          "title": "偏振态的完整表征",
+          "desc": "Stokes矢量与Mueller矩阵"
+        },
+        "s2": {
+          "title": "Jones矩阵与庞加莱球",
+          "desc": "相干光偏振态的几何表示"
+        },
+        "s3": {
+          "title": "全偏振成像技术",
+          "desc": "偏振显微镜与Mueller成像"
+        }
+      }
+    },
     "courseOutline": {
       "title": "课程大纲",
       "badge": "PSRT课程",

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,12 +1,13 @@
 /**
  * HomePage - PSRT Course Homepage
- * 首页 = PSRT课程（融合演示、游戏、工具作为学习资源）
+ * 首页 - 以五单元课程大纲为主框架
  *
- * 架构：首页直接展示PSRT课程的三阶段学习路径
- * 演示(demos)、游戏(games)、工具(tools)作为每个阶段的学习资源
+ * 架构：以PSRT课程大纲的5个单元为核心展开
+ * 将"偏振演示馆"、"光学设计室"、"光的编年史"融合到每个单元中
+ * 采用探索和游戏化模式，避免信息过载
  */
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { LanguageThemeSwitcher } from '@/components/ui/LanguageThemeSwitcher'
@@ -21,104 +22,270 @@ import {
   BookOpen,
   Telescope,
   FlaskConical,
-  Target,
   ArrowRight,
   Eye,
   Wrench,
-  TrendingUp,
-  Clock,
-  Flame,
-  X,
   ChevronDown,
   Sparkles,
   Zap,
   GraduationCap,
+  Atom,
+  Microscope,
+  Sun,
+  Layers,
+  History,
+  Gamepad2,
+  Calculator,
+  Compass,
+  Target,
+  Beaker,
 } from 'lucide-react'
 
-// Learning stage definition - 三阶段认知旅程
-interface LearningStage {
+// ============================================================================
+// 课程大纲数据结构 - 5个单元
+// ============================================================================
+
+interface UnitResource {
+  type: 'demo' | 'experiment' | 'history' | 'game' | 'tool'
   id: string
-  phase: number
+  titleKey: string
+  link: string
+  icon?: React.ReactNode
+}
+
+interface CourseSection {
+  id: string
+  titleKey: string
+  descKey: string
+  resources: UnitResource[]
+}
+
+interface CourseUnit {
+  id: string
+  number: number
   titleKey: string
   subtitleKey: string
-  questionKey: string
+  descriptionKey: string
   icon: React.ReactNode
   color: string
   gradient: string
-  demos: { id: string; titleKey: string; link: string }[]
-  games?: { titleKey: string; link: string }[]
-  tools?: { titleKey: string; link: string }[]
-  isAdvanced?: boolean
+  bgPattern: string
+  sections: CourseSection[]
+  keyExperiment?: {
+    titleKey: string
+    link: string
+  }
 }
 
-// 三阶段学习路径配置 - 隐藏游戏，专注课程内容
-const LEARNING_STAGES: LearningStage[] = [
+// 5个单元课程数据
+const COURSE_UNITS: CourseUnit[] = [
   {
-    // 阶段一：看见偏振
-    id: 'stage1',
-    phase: 1,
-    titleKey: 'home.stage1.title',
-    subtitleKey: 'home.stage1.subtitle',
-    questionKey: 'home.stage1.question',
-    icon: <Lightbulb className="w-6 h-6" />,
+    // 第一单元：光的偏振态及其调制和测量
+    id: 'unit1',
+    number: 1,
+    titleKey: 'home.units.unit1.title',
+    subtitleKey: 'home.units.unit1.subtitle',
+    descriptionKey: 'home.units.unit1.description',
+    icon: <Lightbulb className="w-5 h-5" />,
     color: '#22D3EE',
     gradient: 'from-cyan-500 to-blue-500',
-    demos: [
-      { id: 'polarization-intro', titleKey: 'home.stage1.demos.intro', link: '/demos/polarization-intro' },
-      { id: 'polarization-types-unified', titleKey: 'home.stage1.demos.types', link: '/demos/polarization-types-unified' },
-      { id: 'optical-bench', titleKey: 'home.stage1.demos.bench', link: '/demos/optical-bench' },
+    bgPattern: 'radial-gradient(circle at 20% 80%, rgba(34, 211, 238, 0.1) 0%, transparent 50%)',
+    keyExperiment: {
+      titleKey: 'home.units.unit1.keyExp',
+      link: '/demos/birefringence',
+    },
+    sections: [
+      {
+        id: '1.1',
+        titleKey: 'home.units.unit1.s1.title',
+        descKey: 'home.units.unit1.s1.desc',
+        resources: [
+          { type: 'demo', id: 'light-wave', titleKey: 'home.res.lightWave', link: '/demos/light-wave', icon: <Sparkles className="w-4 h-4" /> },
+          { type: 'demo', id: 'polarization-intro', titleKey: 'home.res.polarIntro', link: '/demos/polarization-intro', icon: <Eye className="w-4 h-4" /> },
+        ],
+      },
+      {
+        id: '1.2',
+        titleKey: 'home.units.unit1.s2.title',
+        descKey: 'home.units.unit1.s2.desc',
+        resources: [
+          { type: 'demo', id: 'birefringence', titleKey: 'home.res.birefringence', link: '/demos/birefringence', icon: <Layers className="w-4 h-4" /> },
+          { type: 'history', id: 'calcite-history', titleKey: 'home.res.calciteHistory', link: '/chronicles?topic=calcite', icon: <History className="w-4 h-4" /> },
+        ],
+      },
+      {
+        id: '1.3',
+        titleKey: 'home.units.unit1.s3.title',
+        descKey: 'home.units.unit1.s3.desc',
+        resources: [
+          { type: 'demo', id: 'malus', titleKey: 'home.res.malus', link: '/demos/malus', icon: <Target className="w-4 h-4" /> },
+          { type: 'experiment', id: 'malus-exp', titleKey: 'home.res.malusExp', link: '/optical-studio?exp=malus', icon: <FlaskConical className="w-4 h-4" /> },
+          { type: 'history', id: 'malus-history', titleKey: 'home.res.malusHistory', link: '/chronicles?topic=malus', icon: <History className="w-4 h-4" /> },
+          { type: 'game', id: 'game-level0', titleKey: 'home.res.gameLevel0', link: '/games/2d?level=0', icon: <Gamepad2 className="w-4 h-4" /> },
+        ],
+      },
     ],
-    // games temporarily hidden
   },
   {
-    // 阶段二：理解规律
-    id: 'stage2',
-    phase: 2,
-    titleKey: 'home.stage2.title',
-    subtitleKey: 'home.stage2.subtitle',
-    questionKey: 'home.stage2.question',
-    icon: <BookOpen className="w-6 h-6" />,
+    // 第二单元：界面反射的偏振特征
+    id: 'unit2',
+    number: 2,
+    titleKey: 'home.units.unit2.title',
+    subtitleKey: 'home.units.unit2.subtitle',
+    descriptionKey: 'home.units.unit2.description',
+    icon: <Zap className="w-5 h-5" />,
     color: '#A78BFA',
-    gradient: 'from-purple-500 to-pink-500',
-    demos: [
-      { id: 'malus', titleKey: 'home.stage2.demos.malus', link: '/demos/malus' },
-      { id: 'birefringence', titleKey: 'home.stage2.demos.birefringence', link: '/demos/birefringence' },
-      { id: 'brewster', titleKey: 'home.stage2.demos.brewster', link: '/demos/brewster' },
-      { id: 'rayleigh', titleKey: 'home.stage2.demos.rayleigh', link: '/demos/rayleigh' },
-      { id: 'chromatic', titleKey: 'home.stage2.demos.chromatic', link: '/demos/chromatic' },
-    ],
-    // games temporarily hidden
-    tools: [
-      { titleKey: 'home.stage2.tools.opticalStudio', link: '/optical-studio?tab=experiments' },
+    gradient: 'from-violet-500 to-purple-500',
+    bgPattern: 'radial-gradient(circle at 80% 20%, rgba(167, 139, 250, 0.1) 0%, transparent 50%)',
+    keyExperiment: {
+      titleKey: 'home.units.unit2.keyExp',
+      link: '/demos/brewster',
+    },
+    sections: [
+      {
+        id: '2.1',
+        titleKey: 'home.units.unit2.s1.title',
+        descKey: 'home.units.unit2.s1.desc',
+        resources: [
+          { type: 'demo', id: 'fresnel', titleKey: 'home.res.fresnel', link: '/demos/fresnel', icon: <Sparkles className="w-4 h-4" /> },
+        ],
+      },
+      {
+        id: '2.2',
+        titleKey: 'home.units.unit2.s2.title',
+        descKey: 'home.units.unit2.s2.desc',
+        resources: [
+          { type: 'demo', id: 'brewster', titleKey: 'home.res.brewster', link: '/demos/brewster', icon: <Zap className="w-4 h-4" /> },
+          { type: 'experiment', id: 'brewster-exp', titleKey: 'home.res.brewsterExp', link: '/optical-studio?exp=brewster', icon: <FlaskConical className="w-4 h-4" /> },
+        ],
+      },
     ],
   },
   {
-    // 阶段三：测量与应用
-    id: 'stage3',
-    phase: 3,
-    titleKey: 'home.stage3.title',
-    subtitleKey: 'home.stage3.subtitle',
-    questionKey: 'home.stage3.question',
-    icon: <Telescope className="w-6 h-6" />,
-    color: '#8B5CF6',
-    gradient: 'from-violet-500 to-purple-600',
-    isAdvanced: true,
-    demos: [
-      { id: 'stokes', titleKey: 'home.stage3.demos.stokes', link: '/demos/stokes' },
-      { id: 'mueller', titleKey: 'home.stage3.demos.mueller', link: '/demos/mueller' },
-      { id: 'jones', titleKey: 'home.stage3.demos.jones', link: '/demos/jones' },
-      { id: 'polarimetric-microscopy', titleKey: 'home.stage3.demos.microscopy', link: '/demos/polarimetric-microscopy' },
+    // 第三单元：透明介质的偏振特征
+    id: 'unit3',
+    number: 3,
+    titleKey: 'home.units.unit3.title',
+    subtitleKey: 'home.units.unit3.subtitle',
+    descriptionKey: 'home.units.unit3.description',
+    icon: <Layers className="w-5 h-5" />,
+    color: '#F59E0B',
+    gradient: 'from-amber-500 to-orange-500',
+    bgPattern: 'radial-gradient(circle at 50% 50%, rgba(245, 158, 11, 0.1) 0%, transparent 50%)',
+    keyExperiment: {
+      titleKey: 'home.units.unit3.keyExp',
+      link: '/demos/chromatic',
+    },
+    sections: [
+      {
+        id: '3.1',
+        titleKey: 'home.units.unit3.s1.title',
+        descKey: 'home.units.unit3.s1.desc',
+        resources: [
+          { type: 'demo', id: 'chromatic', titleKey: 'home.res.chromatic', link: '/demos/chromatic', icon: <Sparkles className="w-4 h-4" /> },
+          { type: 'demo', id: 'anisotropy', titleKey: 'home.res.anisotropy', link: '/demos/anisotropy', icon: <Layers className="w-4 h-4" /> },
+          { type: 'experiment', id: 'stress-exp', titleKey: 'home.res.stressExp', link: '/optical-studio?exp=stress', icon: <FlaskConical className="w-4 h-4" /> },
+        ],
+      },
+      {
+        id: '3.2',
+        titleKey: 'home.units.unit3.s2.title',
+        descKey: 'home.units.unit3.s2.desc',
+        resources: [
+          { type: 'demo', id: 'optical-rotation', titleKey: 'home.res.opticalRotation', link: '/demos/optical-rotation', icon: <Compass className="w-4 h-4" /> },
+          { type: 'experiment', id: 'sugar-exp', titleKey: 'home.res.sugarExp', link: '/experiments?exp=sugar', icon: <Beaker className="w-4 h-4" /> },
+        ],
+      },
     ],
-    // games temporarily hidden
-    tools: [
-      { titleKey: 'home.stage3.tools.stokes', link: '/calc/stokes' },
-      { titleKey: 'home.stage3.tools.poincare', link: '/calc/poincare' },
-      { titleKey: 'home.stage3.tools.mueller', link: '/calc/mueller' },
+  },
+  {
+    // 第四单元：浑浊介质的偏振特征
+    id: 'unit4',
+    number: 4,
+    titleKey: 'home.units.unit4.title',
+    subtitleKey: 'home.units.unit4.subtitle',
+    descriptionKey: 'home.units.unit4.description',
+    icon: <Sun className="w-5 h-5" />,
+    color: '#EC4899',
+    gradient: 'from-pink-500 to-rose-500',
+    bgPattern: 'radial-gradient(circle at 30% 70%, rgba(236, 72, 153, 0.1) 0%, transparent 50%)',
+    keyExperiment: {
+      titleKey: 'home.units.unit4.keyExp',
+      link: '/demos/rayleigh',
+    },
+    sections: [
+      {
+        id: '4.1',
+        titleKey: 'home.units.unit4.s1.title',
+        descKey: 'home.units.unit4.s1.desc',
+        resources: [
+          { type: 'demo', id: 'rayleigh', titleKey: 'home.res.rayleigh', link: '/demos/rayleigh', icon: <Sun className="w-4 h-4" /> },
+          { type: 'demo', id: 'mie', titleKey: 'home.res.mie', link: '/demos/mie-scattering', icon: <Atom className="w-4 h-4" /> },
+        ],
+      },
+      {
+        id: '4.2',
+        titleKey: 'home.units.unit4.s2.title',
+        descKey: 'home.units.unit4.s2.desc',
+        resources: [
+          { type: 'demo', id: 'monte-carlo', titleKey: 'home.res.monteCarlo', link: '/demos/monte-carlo-scattering', icon: <Sparkles className="w-4 h-4" /> },
+        ],
+      },
+    ],
+  },
+  {
+    // 第五单元：全偏振光学技术
+    id: 'unit5',
+    number: 5,
+    titleKey: 'home.units.unit5.title',
+    subtitleKey: 'home.units.unit5.subtitle',
+    descriptionKey: 'home.units.unit5.description',
+    icon: <Microscope className="w-5 h-5" />,
+    color: '#8B5CF6',
+    gradient: 'from-violet-600 to-indigo-600',
+    bgPattern: 'radial-gradient(circle at 70% 30%, rgba(139, 92, 246, 0.1) 0%, transparent 50%)',
+    keyExperiment: {
+      titleKey: 'home.units.unit5.keyExp',
+      link: '/demos/mueller',
+    },
+    sections: [
+      {
+        id: '5.1',
+        titleKey: 'home.units.unit5.s1.title',
+        descKey: 'home.units.unit5.s1.desc',
+        resources: [
+          { type: 'demo', id: 'stokes', titleKey: 'home.res.stokes', link: '/demos/stokes', icon: <Target className="w-4 h-4" /> },
+          { type: 'demo', id: 'mueller', titleKey: 'home.res.mueller', link: '/demos/mueller', icon: <Layers className="w-4 h-4" /> },
+          { type: 'tool', id: 'stokes-calc', titleKey: 'home.res.stokesCalc', link: '/calc/stokes', icon: <Calculator className="w-4 h-4" /> },
+          { type: 'tool', id: 'mueller-calc', titleKey: 'home.res.muellerCalc', link: '/calc/mueller', icon: <Calculator className="w-4 h-4" /> },
+        ],
+      },
+      {
+        id: '5.2',
+        titleKey: 'home.units.unit5.s2.title',
+        descKey: 'home.units.unit5.s2.desc',
+        resources: [
+          { type: 'demo', id: 'jones', titleKey: 'home.res.jones', link: '/demos/jones', icon: <Sparkles className="w-4 h-4" /> },
+          { type: 'tool', id: 'jones-calc', titleKey: 'home.res.jonesCalc', link: '/calc/jones', icon: <Calculator className="w-4 h-4" /> },
+          { type: 'tool', id: 'poincare', titleKey: 'home.res.poincare', link: '/calc/poincare', icon: <Compass className="w-4 h-4" /> },
+        ],
+      },
+      {
+        id: '5.3',
+        titleKey: 'home.units.unit5.s3.title',
+        descKey: 'home.units.unit5.s3.desc',
+        resources: [
+          { type: 'demo', id: 'microscopy', titleKey: 'home.res.microscopy', link: '/demos/polarimetric-microscopy', icon: <Microscope className="w-4 h-4" /> },
+        ],
+      },
     ],
   },
 ]
 
-// Animated polarization background
+// ============================================================================
+// 动态背景组件
+// ============================================================================
+
 function PolarizationBackground({ theme }: { theme: 'dark' | 'light' }) {
   const [time, setTime] = useState(0)
 
@@ -151,688 +318,281 @@ function PolarizationBackground({ theme }: { theme: 'dark' | 'light' }) {
   )
 }
 
-// Learning Stage Card Component - 简化版，点击跳转到课程页
-function LearningStageCard({
-  stage,
+// ============================================================================
+// 资源类型标签组件
+// ============================================================================
+
+function ResourceBadge({ type, theme }: { type: UnitResource['type']; theme: 'dark' | 'light' }) {
+  const { t } = useTranslation()
+
+  const config = {
+    demo: { color: '#22D3EE', labelKey: 'home.resType.demo' },
+    experiment: { color: '#F59E0B', labelKey: 'home.resType.experiment' },
+    history: { color: '#C9A227', labelKey: 'home.resType.history' },
+    game: { color: '#EC4899', labelKey: 'home.resType.game' },
+    tool: { color: '#8B5CF6', labelKey: 'home.resType.tool' },
+  }
+
+  const cfg = config[type]
+
+  return (
+    <span
+      className="text-[9px] px-1.5 py-0.5 rounded font-medium"
+      style={{
+        backgroundColor: `${cfg.color}20`,
+        color: cfg.color,
+      }}
+    >
+      {t(cfg.labelKey)}
+    </span>
+  )
+}
+
+// ============================================================================
+// 单元卡片组件
+// ============================================================================
+
+function UnitCard({
+  unit,
   theme,
+  isExpanded,
+  onToggle,
   completedDemos,
 }: {
-  stage: LearningStage
+  unit: CourseUnit
   theme: 'dark' | 'light'
+  isExpanded: boolean
+  onToggle: () => void
   completedDemos: string[]
 }) {
   const { t } = useTranslation()
 
-  // Calculate progress for this stage
-  const totalDemos = stage.demos.length
-  const completedCount = stage.demos.filter(d => completedDemos.includes(d.id)).length
-  const progressPercent = totalDemos > 0 ? Math.round((completedCount / totalDemos) * 100) : 0
+  // 计算进度
+  const allResources = unit.sections.flatMap(s => s.resources.filter(r => r.type === 'demo'))
+  const completedCount = allResources.filter(r => completedDemos.includes(r.id)).length
+  const progressPercent = allResources.length > 0 ? Math.round((completedCount / allResources.length) * 100) : 0
 
   return (
-    <Link
-      to={`/course?stage=${stage.id}`}
-      className={`group block rounded-xl border transition-all duration-300 hover:-translate-y-1 ${
+    <div
+      className={cn(
+        'rounded-2xl border overflow-hidden transition-all duration-300',
         theme === 'dark'
-          ? 'bg-slate-800/60 border-slate-700/50 hover:border-slate-500'
-          : 'bg-white/80 border-gray-200 hover:border-gray-300'
-      }`}
+          ? 'bg-slate-800/60 border-slate-700/50'
+          : 'bg-white/90 border-gray-200'
+      )}
       style={{
-        boxShadow: `0 4px 20px ${stage.color}10`,
-      }}
-      onMouseEnter={(e) => {
-        e.currentTarget.style.borderColor = stage.color
-        e.currentTarget.style.boxShadow = `0 8px 30px ${stage.color}25`
-      }}
-      onMouseLeave={(e) => {
-        e.currentTarget.style.borderColor = ''
-        e.currentTarget.style.boxShadow = `0 4px 20px ${stage.color}10`
+        borderColor: isExpanded ? unit.color : undefined,
+        boxShadow: isExpanded ? `0 4px 30px ${unit.color}20` : undefined,
+        background: isExpanded ? unit.bgPattern : undefined,
       }}
     >
-      <div className="p-4">
-        <div className="flex items-center gap-3">
-          {/* Phase number badge */}
-          <div
-            className={`flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center bg-gradient-to-br ${stage.gradient} shadow-md`}
-          >
-            <span className="text-white text-lg font-bold">{stage.phase}</span>
-          </div>
-
-          {/* Stage info */}
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2">
-              <h3 className={`text-sm font-bold truncate ${
-                theme === 'dark' ? 'text-white' : 'text-gray-900'
-              }`}>
-                {t(stage.titleKey)}
-              </h3>
-              {stage.isAdvanced && (
-                <span className={`text-[9px] px-1.5 py-0.5 rounded-full font-medium flex-shrink-0 ${
-                  theme === 'dark'
-                    ? 'bg-violet-500/20 text-violet-400'
-                    : 'bg-violet-100 text-violet-700'
-                }`}>
-                  {t('home.advanced')}
-                </span>
-              )}
-            </div>
-            <p className={`text-xs mt-0.5 truncate ${theme === 'dark' ? 'text-gray-400' : 'text-gray-500'}`}>
-              {t(stage.subtitleKey)}
-            </p>
-          </div>
-
-          {/* Arrow */}
-          <ArrowRight className={`w-4 h-4 flex-shrink-0 transition-transform group-hover:translate-x-1 ${
-            theme === 'dark' ? 'text-gray-500 group-hover:text-white' : 'text-gray-400 group-hover:text-gray-700'
-          }`} />
-        </div>
-
-        {/* Progress bar */}
-        <div className="mt-3 flex items-center gap-2">
-          <div className={`flex-1 h-1 rounded-full ${
-            theme === 'dark' ? 'bg-slate-700' : 'bg-gray-200'
-          }`}>
-            <div
-              className={`h-full rounded-full bg-gradient-to-r ${stage.gradient} transition-all duration-500`}
-              style={{ width: `${progressPercent}%` }}
-            />
-          </div>
-          <span className={`text-[10px] font-medium ${
-            theme === 'dark' ? 'text-gray-500' : 'text-gray-400'
-          }`}>
-            {completedCount}/{totalDemos}
-          </span>
-        </div>
-      </div>
-    </Link>
-  )
-}
-
-// Quick Stats Component
-function QuickStats({ theme, progress }: { theme: 'dark' | 'light'; progress: ReturnType<typeof useCourseProgress>['progress'] }) {
-  const { t } = useTranslation()
-
-  const allDemoIds = LEARNING_STAGES.flatMap(s => s.demos.map(d => d.id))
-  const completedCount = progress.completedDemos.filter(id => allDemoIds.includes(id)).length
-  const totalCount = allDemoIds.length
-  const timeSpentMinutes = Math.round(progress.totalTimeSpent / 60)
-
-  const stats = [
-    {
-      icon: <TrendingUp className="w-4 h-4" />,
-      label: t('home.stats.completed'),
-      value: `${completedCount}/${totalCount}`,
-      color: '#22c55e',
-    },
-    {
-      icon: <Flame className="w-4 h-4" />,
-      label: t('home.stats.streak'),
-      value: `${progress.streakDays}`,
-      color: '#f59e0b',
-    },
-    {
-      icon: <Clock className="w-4 h-4" />,
-      label: t('home.stats.time'),
-      value: `${timeSpentMinutes}m`,
-      color: '#6366f1',
-    },
-  ]
-
-  return (
-    <div className="flex items-center gap-4">
-      {stats.map((stat, idx) => (
+      {/* 单元头部 - 可点击展开 */}
+      <button
+        className={cn(
+          'w-full p-4 flex items-center gap-4 text-left transition-colors',
+          theme === 'dark' ? 'hover:bg-slate-700/30' : 'hover:bg-gray-50'
+        )}
+        onClick={onToggle}
+      >
+        {/* 单元编号 */}
         <div
-          key={idx}
-          className={`flex items-center gap-2 px-3 py-1.5 rounded-full ${
-            theme === 'dark' ? 'bg-slate-800/80' : 'bg-white/80'
-          }`}
+          className={cn(
+            'flex-shrink-0 w-12 h-12 rounded-xl flex items-center justify-center bg-gradient-to-br shadow-lg',
+            unit.gradient
+          )}
         >
-          <span style={{ color: stat.color }}>{stat.icon}</span>
-          <span className={`text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-500'}`}>
-            {stat.label}
-          </span>
-          <span className={`text-sm font-bold ${theme === 'dark' ? 'text-white' : 'text-gray-900'}`}>
-            {stat.value}
-          </span>
+          <span className="text-white text-xl font-bold">{unit.number}</span>
         </div>
-      ))}
-    </div>
-  )
-}
 
-// Life Scenes & Hands-on Experiments - 生活中的偏振 + 动手实验（融合版）
-function LifeAndExperimentsSection({ theme }: { theme: 'dark' | 'light' }) {
-  const { t } = useTranslation()
+        {/* 单元信息 */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <h3 className={cn(
+              'text-base font-bold truncate',
+              theme === 'dark' ? 'text-white' : 'text-gray-900'
+            )}>
+              {t(unit.titleKey)}
+            </h3>
+          </div>
+          <p className={cn(
+            'text-sm truncate',
+            theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
+          )}>
+            {t(unit.subtitleKey)}
+          </p>
 
-  // 生活中的偏振现象
-  const lifeScenes = [
-    { icon: '🌅', titleKey: 'home.life.sky', descKey: 'home.life.skyDesc', link: '/demos/rayleigh', color: '#F59E0B' },
-    { icon: '📱', titleKey: 'home.life.screen', descKey: 'home.life.screenDesc', link: '/demos/polarization-intro', color: '#3B82F6' },
-    { icon: '🕶️', titleKey: 'home.life.sunglasses', descKey: 'home.life.sunglassesDesc', link: '/demos/malus', color: '#8B5CF6' },
-    { icon: '🦋', titleKey: 'home.life.butterfly', descKey: 'home.life.butterflyDesc', link: '/demos/chromatic', color: '#EC4899' },
-  ]
-
-  // 简单动手实验
-  const experiments = [
-    { icon: '🌈', titleKey: 'home.exp.sugarRainbow', descKey: 'home.exp.sugarRainbowDesc', link: '/demos/optical-rotation', color: '#EC4899' },
-    { icon: '🎨', titleKey: 'home.exp.tapeArt', descKey: 'home.exp.tapeArtDesc', link: '/demos/chromatic', color: '#8B5CF6' },
-    { icon: '📺', titleKey: 'home.exp.screenPolarizer', descKey: 'home.exp.screenPolarizerDesc', link: '/demos/malus', color: '#3B82F6' },
-  ]
-
-  return (
-    <div className="mb-8 grid grid-cols-1 md:grid-cols-2 gap-4">
-      {/* 生活中的偏振 */}
-      <div className={`rounded-xl p-4 ${theme === 'dark' ? 'bg-slate-800/50' : 'bg-white/80'}`}>
-        <h3 className={`text-sm font-bold mb-3 flex items-center gap-2 ${
-          theme === 'dark' ? 'text-white' : 'text-gray-900'
-        }`}>
-          <Eye className="w-4 h-4 text-cyan-500" />
-          {t('home.lifeTitle')}
-        </h3>
-        <div className="grid grid-cols-2 gap-2">
-          {lifeScenes.map((item, idx) => (
-            <Link
-              key={idx}
-              to={item.link}
-              className={`group p-2.5 rounded-lg transition-all hover:scale-[1.02] ${
-                theme === 'dark'
-                  ? 'bg-slate-700/50 hover:bg-slate-700'
-                  : 'bg-gray-50 hover:bg-gray-100'
-              }`}
-            >
-              <div className="flex items-center gap-2">
-                <span className="text-lg">{item.icon}</span>
-                <div className="flex-1 min-w-0">
-                  <p className={`text-xs font-medium truncate ${
-                    theme === 'dark' ? 'text-white' : 'text-gray-900'
-                  }`}>
-                    {t(item.titleKey)}
-                  </p>
-                  <p className={`text-[10px] truncate ${
-                    theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
-                  }`}>
-                    {t(item.descKey)}
-                  </p>
-                </div>
-              </div>
-            </Link>
-          ))}
-        </div>
-      </div>
-
-      {/* 动手实验 */}
-      <div className={`rounded-xl p-4 ${theme === 'dark' ? 'bg-slate-800/50' : 'bg-white/80'}`}>
-        <h3 className={`text-sm font-bold mb-3 flex items-center gap-2 ${
-          theme === 'dark' ? 'text-white' : 'text-gray-900'
-        }`}>
-          <FlaskConical className="w-4 h-4 text-pink-500" />
-          {t('home.expTitle')}
-        </h3>
-        <div className="space-y-2">
-          {experiments.map((item, idx) => (
-            <Link
-              key={idx}
-              to={item.link}
-              className={`group flex items-center gap-3 p-2.5 rounded-lg transition-all hover:scale-[1.01] ${
-                theme === 'dark'
-                  ? 'bg-slate-700/50 hover:bg-slate-700'
-                  : 'bg-gray-50 hover:bg-gray-100'
-              }`}
-            >
-              <span className="text-lg flex-shrink-0">{item.icon}</span>
-              <div className="flex-1 min-w-0">
-                <p className={`text-xs font-medium truncate ${
-                  theme === 'dark' ? 'text-white' : 'text-gray-900'
-                }`}>
-                  {t(item.titleKey)}
-                </p>
-                <p className={`text-[10px] truncate ${
-                  theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
-                }`}>
-                  {t(item.descKey)}
-                </p>
-              </div>
-              <ArrowRight className={`w-3 h-3 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity ${
-                theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
-              }`} />
-            </Link>
-          ))}
-        </div>
-      </div>
-    </div>
-  )
-}
-
-// Course curriculum data - 课程大纲详细内容
-interface CourseSection {
-  id: string
-  titleKey: string
-  descKey: string
-  demoLink?: string
-}
-
-interface CourseUnit {
-  id: string
-  titleKey: string
-  subtitleKey: string
-  icon: React.ReactNode
-  color: string
-  sections: CourseSection[]
-}
-
-interface CourseStage {
-  id: string
-  phase: number
-  titleKey: string
-  subtitleKey: string
-  descriptionKey: string
-  questionKey: string
-  icon: React.ReactNode
-  color: string
-  gradient: string
-  units: CourseUnit[]
-  isAdvanced?: boolean
-}
-
-const COURSE_CURRICULUM: CourseStage[] = [
-  {
-    id: 'stage1',
-    phase: 1,
-    titleKey: 'home.stage1.title',
-    subtitleKey: 'home.stage1.subtitle',
-    descriptionKey: 'home.courseOutline.stage1.description',
-    questionKey: 'home.stage1.question',
-    icon: <Lightbulb className="w-5 h-5" />,
-    color: '#22D3EE',
-    gradient: 'from-cyan-500 to-blue-500',
-    units: [
-      {
-        id: 'seeing-polarization',
-        titleKey: 'home.courseOutline.stage1.units.seeing.title',
-        subtitleKey: 'home.courseOutline.stage1.units.seeing.subtitle',
-        icon: <Lightbulb className="w-4 h-4" />,
-        color: '#22D3EE',
-        sections: [
-          { id: '1.1', titleKey: 'home.courseOutline.stage1.sections.whatIs', descKey: 'home.courseOutline.stage1.sections.whatIsDesc', demoLink: '/demos/polarization-intro' },
-          { id: '1.2', titleKey: 'home.courseOutline.stage1.sections.types', descKey: 'home.courseOutline.stage1.sections.typesDesc', demoLink: '/demos/polarization-types-unified' },
-          { id: '1.3', titleKey: 'home.courseOutline.stage1.sections.daily', descKey: 'home.courseOutline.stage1.sections.dailyDesc', demoLink: '/demos/optical-bench' },
-        ],
-      },
-    ],
-  },
-  {
-    id: 'stage2',
-    phase: 2,
-    titleKey: 'home.stage2.title',
-    subtitleKey: 'home.stage2.subtitle',
-    descriptionKey: 'home.courseOutline.stage2.description',
-    questionKey: 'home.stage2.question',
-    icon: <BookOpen className="w-5 h-5" />,
-    color: '#A78BFA',
-    gradient: 'from-purple-500 to-pink-500',
-    units: [
-      {
-        id: 'malus-law',
-        titleKey: 'home.courseOutline.stage2.units.malus.title',
-        subtitleKey: 'home.courseOutline.stage2.units.malus.subtitle',
-        icon: <Target className="w-4 h-4" />,
-        color: '#F59E0B',
-        sections: [
-          { id: '2.1', titleKey: 'home.courseOutline.stage2.sections.malus', descKey: 'home.courseOutline.stage2.sections.malusDesc', demoLink: '/demos/malus' },
-        ],
-      },
-      {
-        id: 'birefringence',
-        titleKey: 'home.courseOutline.stage2.units.birefringence.title',
-        subtitleKey: 'home.courseOutline.stage2.units.birefringence.subtitle',
-        icon: <Sparkles className="w-4 h-4" />,
-        color: '#0891B2',
-        sections: [
-          { id: '2.2', titleKey: 'home.courseOutline.stage2.sections.calcite', descKey: 'home.courseOutline.stage2.sections.calciteDesc', demoLink: '/demos/birefringence' },
-          { id: '2.3', titleKey: 'home.courseOutline.stage2.sections.waveplate', descKey: 'home.courseOutline.stage2.sections.waveplateDesc', demoLink: '/demos/waveplate' },
-        ],
-      },
-      {
-        id: 'reflection',
-        titleKey: 'home.courseOutline.stage2.units.reflection.title',
-        subtitleKey: 'home.courseOutline.stage2.units.reflection.subtitle',
-        icon: <Zap className="w-4 h-4" />,
-        color: '#6366F1',
-        sections: [
-          { id: '2.4', titleKey: 'home.courseOutline.stage2.sections.brewster', descKey: 'home.courseOutline.stage2.sections.brewsterDesc', demoLink: '/demos/brewster' },
-        ],
-      },
-      {
-        id: 'scattering',
-        titleKey: 'home.courseOutline.stage2.units.scattering.title',
-        subtitleKey: 'home.courseOutline.stage2.units.scattering.subtitle',
-        icon: <Target className="w-4 h-4" />,
-        color: '#F59E0B',
-        sections: [
-          { id: '2.5', titleKey: 'home.courseOutline.stage2.sections.rayleigh', descKey: 'home.courseOutline.stage2.sections.rayleighDesc', demoLink: '/demos/rayleigh' },
-        ],
-      },
-      {
-        id: 'applications',
-        titleKey: 'home.courseOutline.stage2.units.applications.title',
-        subtitleKey: 'home.courseOutline.stage2.units.applications.subtitle',
-        icon: <Sparkles className="w-4 h-4" />,
-        color: '#EC4899',
-        sections: [
-          { id: '2.6', titleKey: 'home.courseOutline.stage2.sections.stress', descKey: 'home.courseOutline.stage2.sections.stressDesc', demoLink: '/demos/anisotropy' },
-          { id: '2.7', titleKey: 'home.courseOutline.stage2.sections.sugar', descKey: 'home.courseOutline.stage2.sections.sugarDesc', demoLink: '/demos/optical-rotation' },
-        ],
-      },
-    ],
-  },
-  {
-    id: 'stage3',
-    phase: 3,
-    titleKey: 'home.stage3.title',
-    subtitleKey: 'home.stage3.subtitle',
-    descriptionKey: 'home.courseOutline.stage3.description',
-    questionKey: 'home.stage3.question',
-    icon: <Telescope className="w-5 h-5" />,
-    color: '#8B5CF6',
-    gradient: 'from-violet-500 to-purple-600',
-    isAdvanced: true,
-    units: [
-      {
-        id: 'stokes-vector',
-        titleKey: 'home.courseOutline.stage3.units.stokes.title',
-        subtitleKey: 'home.courseOutline.stage3.units.stokes.subtitle',
-        icon: <Target className="w-4 h-4" />,
-        color: '#8B5CF6',
-        sections: [
-          { id: '3.1', titleKey: 'home.courseOutline.stage3.sections.stokes', descKey: 'home.courseOutline.stage3.sections.stokesDesc', demoLink: '/demos/stokes' },
-        ],
-      },
-      {
-        id: 'mueller-matrix',
-        titleKey: 'home.courseOutline.stage3.units.mueller.title',
-        subtitleKey: 'home.courseOutline.stage3.units.mueller.subtitle',
-        icon: <Telescope className="w-4 h-4" />,
-        color: '#EC4899',
-        sections: [
-          { id: '3.2', titleKey: 'home.courseOutline.stage3.sections.mueller', descKey: 'home.courseOutline.stage3.sections.muellerDesc', demoLink: '/demos/mueller' },
-          { id: '3.3', titleKey: 'home.courseOutline.stage3.sections.jones', descKey: 'home.courseOutline.stage3.sections.jonesDesc', demoLink: '/demos/jones' },
-        ],
-      },
-      {
-        id: 'advanced-imaging',
-        titleKey: 'home.courseOutline.stage3.units.imaging.title',
-        subtitleKey: 'home.courseOutline.stage3.units.imaging.subtitle',
-        icon: <Telescope className="w-4 h-4" />,
-        color: '#06B6D4',
-        sections: [
-          { id: '3.4', titleKey: 'home.courseOutline.stage3.sections.microscopy', descKey: 'home.courseOutline.stage3.sections.microscopyDesc', demoLink: '/demos/polarimetric-microscopy' },
-          { id: '3.5', titleKey: 'home.courseOutline.stage3.sections.monteCarlo', descKey: 'home.courseOutline.stage3.sections.monteCarloDesc', demoLink: '/demos/monte-carlo-scattering' },
-        ],
-      },
-    ],
-  },
-]
-
-// Course Outline Section - 课程大纲（可展开的详细内容）
-function CourseOutlineSection({ theme }: { theme: 'dark' | 'light' }) {
-  const { t } = useTranslation()
-  const [expandedStageId, setExpandedStageId] = useState<string | null>(null)
-  const [expandedUnitId, setExpandedUnitId] = useState<string | null>(null)
-
-  return (
-    <div className="mb-8">
-      {/* Section header */}
-      <div className="flex items-center gap-3 mb-4">
-        <div className="p-2 rounded-full bg-gradient-to-br from-blue-400 to-indigo-500">
-          <GraduationCap className="w-4 h-4 text-white" />
-        </div>
-        <h2 className={`text-lg font-bold ${
-          theme === 'dark' ? 'text-white' : 'text-gray-900'
-        }`}>
-          {t('home.courseOutline.title')}
-        </h2>
-        <span className={`text-[10px] px-2 py-0.5 rounded-full font-medium ${
-          theme === 'dark'
-            ? 'bg-blue-500/20 text-blue-400'
-            : 'bg-blue-100 text-blue-700'
-        }`}>
-          {t('home.courseOutline.badge')}
-        </span>
-      </div>
-
-      {/* Course stages */}
-      <div className="space-y-3">
-        {COURSE_CURRICULUM.map((stage) => (
-          <div
-            key={stage.id}
-            className={`rounded-xl border overflow-hidden transition-all duration-300 ${
-              theme === 'dark'
-                ? 'bg-slate-800/60 border-slate-700/50'
-                : 'bg-white/90 border-gray-200'
-            }`}
-            style={{
-              borderColor: expandedStageId === stage.id ? stage.color : undefined,
-              boxShadow: expandedStageId === stage.id ? `0 4px 20px ${stage.color}20` : undefined,
-            }}
-          >
-            {/* Stage header */}
-            <button
-              className={`w-full p-4 flex items-center gap-4 transition-colors ${
-                theme === 'dark' ? 'hover:bg-slate-700/30' : 'hover:bg-gray-50'
-              }`}
-              onClick={() => setExpandedStageId(expandedStageId === stage.id ? null : stage.id)}
-            >
-              {/* Phase badge */}
+          {/* 进度条 */}
+          <div className="mt-2 flex items-center gap-2">
+            <div className={cn(
+              'flex-1 h-1 rounded-full',
+              theme === 'dark' ? 'bg-slate-700' : 'bg-gray-200'
+            )}>
               <div
-                className={`flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center bg-gradient-to-br ${stage.gradient}`}
-              >
-                <span className="text-white text-lg font-bold">{stage.phase}</span>
-              </div>
+                className={cn('h-full rounded-full bg-gradient-to-r transition-all', unit.gradient)}
+                style={{ width: `${progressPercent}%` }}
+              />
+            </div>
+            <span className={cn(
+              'text-[10px] font-medium',
+              theme === 'dark' ? 'text-gray-500' : 'text-gray-400'
+            )}>
+              {completedCount}/{allResources.length}
+            </span>
+          </div>
+        </div>
 
-              {/* Stage info */}
-              <div className="flex-1 text-left">
-                <div className="flex items-center gap-2">
-                  <h3 className={`font-bold ${
+        {/* 展开指示器 */}
+        <ChevronDown
+          className={cn(
+            'w-5 h-5 flex-shrink-0 transition-transform duration-300',
+            isExpanded ? 'rotate-180' : '',
+            theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
+          )}
+        />
+      </button>
+
+      {/* 展开内容 */}
+      {isExpanded && (
+        <div className={cn(
+          'px-4 pb-4 border-t',
+          theme === 'dark' ? 'border-slate-700/50' : 'border-gray-100'
+        )}>
+          {/* 单元描述 */}
+          <p className={cn(
+            'text-sm mt-3 mb-4',
+            theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
+          )}>
+            {t(unit.descriptionKey)}
+          </p>
+
+          {/* 核心实验入口 */}
+          {unit.keyExperiment && (
+            <Link
+              to={unit.keyExperiment.link}
+              className={cn(
+                'flex items-center gap-3 p-3 rounded-xl mb-4 transition-all hover:scale-[1.01]',
+                'bg-gradient-to-r text-white shadow-lg',
+                unit.gradient
+              )}
+            >
+              <div className="p-2 bg-white/20 rounded-lg">
+                <FlaskConical className="w-5 h-5" />
+              </div>
+              <div className="flex-1">
+                <p className="text-xs opacity-80">{t('home.keyExperiment')}</p>
+                <p className="font-medium">{t(unit.keyExperiment.titleKey)}</p>
+              </div>
+              <ArrowRight className="w-5 h-5" />
+            </Link>
+          )}
+
+          {/* 各小节内容 */}
+          <div className="space-y-4">
+            {unit.sections.map((section) => (
+              <div key={section.id}>
+                {/* 小节标题 */}
+                <div className="flex items-center gap-2 mb-2">
+                  <span
+                    className="text-xs font-bold px-2 py-0.5 rounded"
+                    style={{ backgroundColor: `${unit.color}20`, color: unit.color }}
+                  >
+                    {section.id}
+                  </span>
+                  <h4 className={cn(
+                    'text-sm font-semibold',
                     theme === 'dark' ? 'text-white' : 'text-gray-900'
-                  }`}>
-                    {t(stage.titleKey)}
-                  </h3>
-                  {stage.isAdvanced && (
-                    <span className={`text-[9px] px-1.5 py-0.5 rounded-full font-medium ${
-                      theme === 'dark'
-                        ? 'bg-violet-500/20 text-violet-400'
-                        : 'bg-violet-100 text-violet-700'
-                    }`}>
-                      {t('home.advanced')}
-                    </span>
-                  )}
+                  )}>
+                    {t(section.titleKey)}
+                  </h4>
                 </div>
-                <p className={`text-sm ${theme === 'dark' ? 'text-gray-400' : 'text-gray-500'}`}>
-                  {t(stage.subtitleKey)}
-                </p>
-              </div>
-
-              {/* Unit count & expand icon */}
-              <div className="flex items-center gap-2">
-                <span className={`text-xs px-2 py-1 rounded-full ${
-                  theme === 'dark' ? 'bg-slate-700 text-gray-400' : 'bg-gray-100 text-gray-500'
-                }`}>
-                  {stage.units.length} {t('home.courseOutline.units')}
-                </span>
-                <ChevronDown
-                  className={`w-5 h-5 transition-transform duration-300 ${
-                    expandedStageId === stage.id ? 'rotate-180' : ''
-                  } ${theme === 'dark' ? 'text-gray-400' : 'text-gray-500'}`}
-                />
-              </div>
-            </button>
-
-            {/* Expanded content */}
-            {expandedStageId === stage.id && (
-              <div className={`px-4 pb-4 border-t ${
-                theme === 'dark' ? 'border-slate-700/50' : 'border-gray-100'
-              }`}>
-                {/* Stage question */}
-                <p className={`text-sm mt-3 mb-4 italic ${
-                  theme === 'dark' ? 'text-cyan-400' : 'text-cyan-600'
-                }`}>
-                  "{t(stage.questionKey)}"
+                <p className={cn(
+                  'text-xs mb-2',
+                  theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+                )}>
+                  {t(section.descKey)}
                 </p>
 
-                {/* Units list */}
-                <div className="space-y-2">
-                  {stage.units.map((unit) => (
-                    <div
-                      key={unit.id}
-                      className={`rounded-lg border overflow-hidden transition-all ${
+                {/* 资源列表 */}
+                <div className="flex flex-wrap gap-2">
+                  {section.resources.map((resource) => (
+                    <Link
+                      key={resource.id}
+                      to={resource.link}
+                      className={cn(
+                        'group flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-all hover:scale-105',
                         theme === 'dark'
-                          ? 'bg-slate-700/30 border-slate-600/50'
-                          : 'bg-gray-50 border-gray-200'
-                      }`}
-                      style={{
-                        borderColor: expandedUnitId === unit.id ? unit.color : undefined,
-                      }}
-                    >
-                      {/* Unit header */}
-                      <button
-                        className={`w-full p-3 flex items-center gap-3 transition-colors ${
-                          theme === 'dark' ? 'hover:bg-slate-600/30' : 'hover:bg-gray-100'
-                        }`}
-                        onClick={() => setExpandedUnitId(expandedUnitId === unit.id ? null : unit.id)}
-                      >
-                        <div
-                          className="w-7 h-7 rounded-lg flex items-center justify-center flex-shrink-0"
-                          style={{ backgroundColor: `${unit.color}20` }}
-                        >
-                          <span style={{ color: unit.color }}>{unit.icon}</span>
-                        </div>
-                        <div className="flex-1 text-left">
-                          <h4 className={`text-sm font-medium ${
-                            theme === 'dark' ? 'text-white' : 'text-gray-900'
-                          }`}>
-                            {t(unit.titleKey)}
-                          </h4>
-                          <p className={`text-xs ${
-                            theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
-                          }`}>
-                            {t(unit.subtitleKey)}
-                          </p>
-                        </div>
-                        <ChevronDown
-                          className={`w-4 h-4 transition-transform duration-200 ${
-                            expandedUnitId === unit.id ? 'rotate-180' : ''
-                          } ${theme === 'dark' ? 'text-gray-500' : 'text-gray-400'}`}
-                        />
-                      </button>
-
-                      {/* Unit sections */}
-                      {expandedUnitId === unit.id && (
-                        <div className={`px-3 pb-3 border-t ${
-                          theme === 'dark' ? 'border-slate-600/30' : 'border-gray-200'
-                        }`}>
-                          <div className="mt-2 space-y-1.5">
-                            {unit.sections.map((section) => (
-                              <Link
-                                key={section.id}
-                                to={section.demoLink || '#'}
-                                className={`group block p-2 rounded-md transition-all hover:scale-[1.01] ${
-                                  theme === 'dark'
-                                    ? 'bg-slate-600/30 hover:bg-slate-600/50'
-                                    : 'bg-white hover:bg-gray-50'
-                                }`}
-                              >
-                                <div className="flex items-center gap-2">
-                                  <span
-                                    className="text-[10px] font-bold px-1.5 py-0.5 rounded"
-                                    style={{ backgroundColor: `${unit.color}20`, color: unit.color }}
-                                  >
-                                    {section.id}
-                                  </span>
-                                  <div className="flex-1 min-w-0">
-                                    <p className={`text-xs font-medium truncate ${
-                                      theme === 'dark' ? 'text-white' : 'text-gray-900'
-                                    }`}>
-                                      {t(section.titleKey)}
-                                    </p>
-                                    <p className={`text-[10px] truncate ${
-                                      theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
-                                    }`}>
-                                      {t(section.descKey)}
-                                    </p>
-                                  </div>
-                                  <ArrowRight className={`w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity ${
-                                    theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
-                                  }`} />
-                                </div>
-                              </Link>
-                            ))}
-                          </div>
-                        </div>
+                          ? 'bg-slate-700/50 hover:bg-slate-700'
+                          : 'bg-gray-50 hover:bg-gray-100'
                       )}
-                    </div>
+                    >
+                      <span style={{ color: unit.color }}>{resource.icon}</span>
+                      <span className={cn(
+                        'font-medium',
+                        theme === 'dark' ? 'text-white' : 'text-gray-700'
+                      )}>
+                        {t(resource.titleKey)}
+                      </span>
+                      <ResourceBadge type={resource.type} theme={theme} />
+                    </Link>
                   ))}
                 </div>
               </div>
-            )}
+            ))}
           </div>
-        ))}
-      </div>
-
-      {/* View full course link */}
-      <div className="mt-4 text-center">
-        <Link
-          to="/course"
-          className={`inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-all hover:scale-105 ${
-            theme === 'dark'
-              ? 'bg-slate-800 text-cyan-400 hover:bg-slate-700'
-              : 'bg-gray-100 text-cyan-600 hover:bg-gray-200'
-          }`}
-        >
-          {t('home.courseOutline.viewFull')}
-          <ArrowRight className="w-4 h-4" />
-        </Link>
-      </div>
+        </div>
+      )}
     </div>
   )
 }
 
-// Quick Access Menu - 快捷入口（精简版：隐藏游戏、实验室、造物局）
-function QuickAccessMenu({ theme }: { theme: 'dark' | 'light' }) {
+// ============================================================================
+// 快速入口组件
+// ============================================================================
+
+function QuickAccessSection({ theme }: { theme: 'dark' | 'light' }) {
   const { t } = useTranslation()
 
-  // 保留核心模块：演示馆、计算工具、历史编年史、光学设计室
   const quickLinks = [
-    { icon: <FlaskConical className="w-4 h-4" />, label: t('home.quick.demos'), link: '/demos', color: '#0891B2' },
-    { icon: <Target className="w-4 h-4" />, label: t('home.quick.calc'), link: '/calc', color: '#8B5CF6' },
-    { icon: <Wrench className="w-4 h-4" />, label: t('home.quick.opticalStudio'), link: '/optical-studio', color: '#F59E0B' },
-    { icon: <BookOpen className="w-4 h-4" />, label: t('home.quick.chronicles'), link: '/chronicles', color: '#C9A227' },
+    { icon: <Eye className="w-5 h-5" />, labelKey: 'home.quick.demos', link: '/demos', color: '#22D3EE' },
+    { icon: <Wrench className="w-5 h-5" />, labelKey: 'home.quick.opticalStudio', link: '/optical-studio', color: '#F59E0B' },
+    { icon: <History className="w-5 h-5" />, labelKey: 'home.quick.chronicles', link: '/chronicles', color: '#C9A227' },
+    { icon: <Calculator className="w-5 h-5" />, labelKey: 'home.quick.calc', link: '/calc', color: '#8B5CF6' },
   ]
 
   return (
-    <div className={`rounded-xl p-4 ${theme === 'dark' ? 'bg-slate-800/50' : 'bg-white/80'}`}>
-      <h3 className={`text-sm font-semibold mb-3 ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}`}>
+    <div className={cn(
+      'rounded-xl p-4 mb-6',
+      theme === 'dark' ? 'bg-slate-800/50' : 'bg-white/80'
+    )}>
+      <h3 className={cn(
+        'text-sm font-semibold mb-3',
+        theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+      )}>
         {t('home.quickAccess')}
       </h3>
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         {quickLinks.map((item, idx) => (
           <Link
             key={idx}
             to={item.link}
-            className={`flex flex-col items-center gap-1.5 p-3 rounded-lg transition-all hover:scale-105 ${
+            className={cn(
+              'flex flex-col items-center gap-2 p-4 rounded-xl transition-all hover:scale-105',
               theme === 'dark'
                 ? 'bg-slate-700/50 hover:bg-slate-700'
                 : 'bg-gray-50 hover:bg-gray-100'
-            }`}
+            )}
           >
             <div
-              className="w-8 h-8 rounded-lg flex items-center justify-center"
+              className="w-10 h-10 rounded-xl flex items-center justify-center"
               style={{ backgroundColor: `${item.color}20` }}
             >
               <span style={{ color: item.color }}>{item.icon}</span>
             </div>
-            <span className={`text-[10px] font-medium text-center ${
+            <span className={cn(
+              'text-xs font-medium text-center',
               theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
-            }`}>
-              {item.label}
+            )}>
+              {t(item.labelKey)}
             </span>
           </Link>
         ))}
@@ -841,134 +601,69 @@ function QuickAccessMenu({ theme }: { theme: 'dark' | 'light' }) {
   )
 }
 
-// Guided Start Modal - 引导式起点（隐藏游戏路径）
-const LEARNING_TRACKS = [
-  {
-    id: 'curious',
-    icon: Lightbulb,
-    color: '#22D3EE',
-    gradient: 'from-cyan-500 to-blue-500',
-    route: '/demos/polarization-intro',
-  },
-  {
-    id: 'student',
-    icon: BookOpen,
-    color: '#A78BFA',
-    gradient: 'from-purple-500 to-pink-500',
-    route: '/demos/malus',
-  },
-  {
-    id: 'researcher',
-    icon: Telescope,
-    color: '#8B5CF6',
-    gradient: 'from-violet-500 to-purple-600',
-    route: '/demos/stokes',
-  },
-  // player track temporarily hidden
-]
+// ============================================================================
+// 生活场景卡片
+// ============================================================================
 
-function GuidedStartModal({
-  theme,
-  onClose,
-  onSelect,
-}: {
-  theme: 'dark' | 'light'
-  onClose: () => void
-  onSelect: (trackId: string, route: string) => void
-}) {
+function LifeScenesSection({ theme }: { theme: 'dark' | 'light' }) {
   const { t } = useTranslation()
 
+  const scenes = [
+    { emoji: '🌅', titleKey: 'home.life.sky', descKey: 'home.life.skyDesc', link: '/demos/rayleigh', color: '#F59E0B' },
+    { emoji: '📱', titleKey: 'home.life.screen', descKey: 'home.life.screenDesc', link: '/demos/polarization-intro', color: '#3B82F6' },
+    { emoji: '🕶️', titleKey: 'home.life.sunglasses', descKey: 'home.life.sunglassesDesc', link: '/demos/malus', color: '#8B5CF6' },
+    { emoji: '🦋', titleKey: 'home.life.butterfly', descKey: 'home.life.butterflyDesc', link: '/demos/chromatic', color: '#EC4899' },
+  ]
+
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
-      <div className={`relative w-full max-w-xl rounded-2xl p-6 shadow-2xl ${
-        theme === 'dark'
-          ? 'bg-slate-900 border border-slate-700'
-          : 'bg-white border border-gray-200'
-      }`}>
-        <button
-          onClick={onClose}
-          className={`absolute top-4 right-4 p-2 rounded-full transition-colors ${
-            theme === 'dark'
-              ? 'text-gray-400 hover:text-white hover:bg-slate-700'
-              : 'text-gray-500 hover:text-gray-900 hover:bg-gray-100'
-          }`}
-        >
-          <X className="w-5 h-5" />
-        </button>
-
-        <div className="text-center mb-6">
-          <h2 className={`text-2xl font-bold mb-2 ${
-            theme === 'dark' ? 'text-white' : 'text-gray-900'
-          }`}>
-            {t('home.guidedStart.title')}
-          </h2>
-          <p className={`text-sm ${
-            theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
-          }`}>
-            {t('home.guidedStart.subtitle')}
-          </p>
-        </div>
-
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-          {LEARNING_TRACKS.map((track) => {
-            const IconComponent = track.icon
-            return (
-              <button
-                key={track.id}
-                onClick={() => onSelect(track.id, track.route)}
-                className={`group p-4 rounded-xl border-2 text-left transition-all hover:scale-[1.02] ${
-                  theme === 'dark'
-                    ? 'bg-slate-800/50 border-slate-700 hover:border-slate-500'
-                    : 'bg-gray-50 border-gray-200 hover:border-gray-400'
-                }`}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.borderColor = track.color
-                  e.currentTarget.style.boxShadow = `0 0 20px ${track.color}30`
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.borderColor = ''
-                  e.currentTarget.style.boxShadow = ''
-                }}
-              >
-                <div className="flex flex-col items-center text-center gap-2">
-                  <div className={`p-3 rounded-xl bg-gradient-to-br ${track.gradient}`}>
-                    <IconComponent className="w-6 h-6 text-white" />
-                  </div>
-                  <div>
-                    <h3 className={`font-semibold mb-1 ${
-                      theme === 'dark' ? 'text-white' : 'text-gray-900'
-                    }`}>
-                      {t(`home.guidedStart.tracks.${track.id}.title`)}
-                    </h3>
-                    <p className={`text-xs ${
-                      theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
-                    }`}>
-                      {t(`home.guidedStart.tracks.${track.id}.description`)}
-                    </p>
-                  </div>
-                </div>
-              </button>
-            )
-          })}
-        </div>
-
-        <div className="mt-4 text-center">
-          <button
-            onClick={onClose}
-            className={`text-sm transition-colors ${
+    <div className={cn(
+      'rounded-xl p-4 mb-6',
+      theme === 'dark' ? 'bg-slate-800/50' : 'bg-white/80'
+    )}>
+      <h3 className={cn(
+        'text-sm font-semibold mb-3 flex items-center gap-2',
+        theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+      )}>
+        <Compass className="w-4 h-4 text-cyan-500" />
+        {t('home.lifeTitle')}
+      </h3>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        {scenes.map((scene, idx) => (
+          <Link
+            key={idx}
+            to={scene.link}
+            className={cn(
+              'group flex items-center gap-2 p-3 rounded-lg transition-all hover:scale-[1.02]',
               theme === 'dark'
-                ? 'text-gray-500 hover:text-gray-300'
-                : 'text-gray-400 hover:text-gray-600'
-            }`}
+                ? 'bg-slate-700/50 hover:bg-slate-700'
+                : 'bg-gray-50 hover:bg-gray-100'
+            )}
           >
-            {t('home.guidedStart.skip')}
-          </button>
-        </div>
+            <span className="text-2xl">{scene.emoji}</span>
+            <div className="flex-1 min-w-0">
+              <p className={cn(
+                'text-xs font-medium truncate',
+                theme === 'dark' ? 'text-white' : 'text-gray-900'
+              )}>
+                {t(scene.titleKey)}
+              </p>
+              <p className={cn(
+                'text-[10px] truncate',
+                theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
+              )}>
+                {t(scene.descKey)}
+              </p>
+            </div>
+          </Link>
+        ))}
       </div>
     </div>
   )
 }
+
+// ============================================================================
+// 主页组件
+// ============================================================================
 
 export function HomePage() {
   const { t } = useTranslation()
@@ -976,205 +671,203 @@ export function HomePage() {
   const navigate = useNavigate()
   const { progress } = useCourseProgress()
 
-  // Guided start modal state
-  const [showGuidedStart, setShowGuidedStart] = useState(() => {
-    const hasSeenGuide = localStorage.getItem('polarcraft_guided_start_completed')
-    return !hasSeenGuide
-  })
+  // 展开状态管理
+  const [expandedUnitId, setExpandedUnitId] = useState<string | null>(null)
 
-  const handleGuidedSelect = useCallback((trackId: string, route: string) => {
-    localStorage.setItem('polarcraft_guided_start_completed', 'true')
-    localStorage.setItem('polarcraft_learning_track', trackId)
-    setShowGuidedStart(false)
-    navigate(route)
-  }, [navigate])
+  // 首个未完成单元自动展开
+  useEffect(() => {
+    const firstIncomplete = COURSE_UNITS.find(unit => {
+      const demos = unit.sections.flatMap(s => s.resources.filter(r => r.type === 'demo'))
+      return demos.some(d => !progress.completedDemos.includes(d.id))
+    })
+    if (firstIncomplete && !expandedUnitId) {
+      setExpandedUnitId(firstIncomplete.id)
+    }
+  }, [progress.completedDemos])
 
-  const handleGuidedClose = useCallback(() => {
-    localStorage.setItem('polarcraft_guided_start_completed', 'true')
-    setShowGuidedStart(false)
+  const handleToggleUnit = useCallback((unitId: string) => {
+    setExpandedUnitId(prev => prev === unitId ? null : unitId)
   }, [])
 
+  const handleStartLearning = useCallback(() => {
+    // 跳转到第一个未完成的演示
+    for (const unit of COURSE_UNITS) {
+      for (const section of unit.sections) {
+        for (const resource of section.resources) {
+          if (resource.type === 'demo' && !progress.completedDemos.includes(resource.id)) {
+            navigate(resource.link)
+            return
+          }
+        }
+      }
+    }
+    // 如果全部完成，跳转到第一个演示
+    navigate('/demos/polarization-intro')
+  }, [navigate, progress.completedDemos])
+
   return (
-    <div className={`min-h-screen ${
+    <div className={cn(
+      'min-h-screen',
       theme === 'dark'
         ? 'bg-gradient-to-br from-[#0a0a1a] via-[#1a1a3a] to-[#0a0a2a]'
         : 'bg-gradient-to-br from-[#f0f9ff] via-[#e0f2fe] to-[#f0f9ff]'
-    }`}>
-      {/* Background */}
+    )}>
+      {/* 动态背景 */}
       <PolarizationBackground theme={theme} />
 
-      {/* Header */}
+      {/* 顶部导航 */}
       <header className="fixed top-0 left-0 right-0 z-50">
-        <div className={`flex items-center justify-between px-4 py-2 ${
+        <div className={cn(
+          'flex items-center justify-between px-4 py-3',
           theme === 'dark'
             ? 'bg-slate-900/90 backdrop-blur-xl border-b border-slate-700/50'
             : 'bg-white/90 backdrop-blur-xl border-b border-gray-200/50'
-        }`}>
+        )}>
           <div className="flex items-center gap-3">
-            <PolarWorldLogo size={40} theme={theme} />
-            <span className={`hidden sm:block font-bold text-lg ${
+            <PolarWorldLogo size={36} theme={theme} />
+            <span className={cn(
+              'hidden sm:block font-bold text-lg',
               theme === 'dark'
                 ? 'text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 to-violet-400'
                 : 'text-transparent bg-clip-text bg-gradient-to-r from-cyan-600 to-violet-600'
-            }`}>
+            )}>
               PolarCraft
             </span>
           </div>
-
-          <div className="flex items-center gap-3">
-            <QuickStats theme={theme} progress={progress} />
-            <LanguageThemeSwitcher />
-          </div>
+          <LanguageThemeSwitcher />
         </div>
       </header>
 
-      {/* Main Content */}
+      {/* 主要内容 */}
       <main className="max-w-4xl mx-auto px-4 pt-20 pb-12">
-        {/* Hero Section - Redesigned for Impact */}
-        <div className="relative mb-12">
-          {/* Dramatic background glow */}
+        {/* Hero 区域 */}
+        <div className="relative mb-8">
+          {/* 背景光晕 */}
           <div className="absolute inset-0 -z-10">
             <div className={cn(
-              'absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] rounded-full blur-[120px]',
+              'absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] rounded-full blur-[100px]',
               theme === 'dark'
                 ? 'bg-gradient-to-r from-cyan-500/20 via-blue-500/15 to-violet-500/20'
                 : 'bg-gradient-to-r from-cyan-400/15 via-blue-400/10 to-violet-400/15'
             )} />
           </div>
 
-          {/* Main Hero Content */}
-          <div className="text-center pt-8 pb-6">
-            {/* Bold Title with Glow Effect */}
+          {/* 标题 */}
+          <div className="text-center pt-6 pb-4">
+            <div className="flex items-center justify-center gap-2 mb-3">
+              <span className={cn(
+                'text-xs px-3 py-1 rounded-full font-medium',
+                theme === 'dark'
+                  ? 'bg-cyan-500/20 text-cyan-400'
+                  : 'bg-cyan-100 text-cyan-700'
+              )}>
+                {t('home.courseBanner.badge')}
+              </span>
+            </div>
+
             <h1 className={cn(
-              'text-5xl sm:text-6xl md:text-7xl font-black tracking-tight mb-4',
+              'text-4xl sm:text-5xl font-black tracking-tight mb-4',
               'text-transparent bg-clip-text',
               theme === 'dark'
                 ? 'bg-gradient-to-br from-white via-cyan-200 to-violet-300'
                 : 'bg-gradient-to-br from-gray-900 via-cyan-700 to-violet-700'
-            )}
-              style={{
-                textShadow: theme === 'dark'
-                  ? '0 0 60px rgba(34, 211, 238, 0.4), 0 0 120px rgba(139, 92, 246, 0.3)'
-                  : 'none'
-              }}
-            >
-              PolarCraft
+            )}>
+              {t('home.title')}
             </h1>
 
-            {/* Animated tagline */}
             <p className={cn(
-              'text-lg sm:text-xl md:text-2xl font-medium mb-6',
-              theme === 'dark' ? 'text-cyan-400' : 'text-cyan-600'
-            )}>
-              {t('home.subtitle')}
-            </p>
-
-            {/* Description */}
-            <p className={cn(
-              'text-base sm:text-lg max-w-2xl mx-auto leading-relaxed mb-8',
+              'text-base sm:text-lg max-w-2xl mx-auto mb-6',
               theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
             )}>
-              {t('home.description')}
+              {t('home.courseBanner.description')}
             </p>
 
-            {/* CTA Buttons - More prominent */}
-            <div className="flex flex-wrap justify-center gap-4">
+            {/* CTA 按钮 */}
+            <div className="flex flex-wrap justify-center gap-3">
               <button
-                onClick={() => {
-                  const firstDemo = LEARNING_STAGES[0].demos[0]
-                  if (firstDemo) navigate(firstDemo.link)
-                }}
+                onClick={handleStartLearning}
                 className={cn(
-                  'group px-8 py-4 rounded-full font-bold text-lg flex items-center gap-3',
+                  'group px-6 py-3 rounded-full font-bold flex items-center gap-2',
                   'bg-gradient-to-r from-cyan-500 via-blue-500 to-violet-500 text-white',
                   'hover:scale-105 transition-all duration-300',
                   'shadow-lg shadow-blue-500/30 hover:shadow-xl hover:shadow-blue-500/40'
                 )}
               >
-                <Play className="w-6 h-6 group-hover:scale-110 transition-transform" />
+                <Play className="w-5 h-5 group-hover:scale-110 transition-transform" />
                 {t('home.startLearning')}
               </button>
               <Link
-                to="/demos"
+                to="/course"
                 className={cn(
-                  'px-8 py-4 rounded-full font-bold text-lg flex items-center gap-3',
+                  'px-6 py-3 rounded-full font-bold flex items-center gap-2',
                   'border-2 transition-all duration-300 hover:scale-105',
                   theme === 'dark'
-                    ? 'border-cyan-500/50 text-cyan-300 hover:border-cyan-400 hover:bg-cyan-500/10'
-                    : 'border-cyan-400 text-cyan-700 hover:border-cyan-500 hover:bg-cyan-50'
+                    ? 'border-slate-600 text-gray-300 hover:border-slate-500 hover:bg-slate-800/50'
+                    : 'border-gray-300 text-gray-700 hover:border-gray-400 hover:bg-gray-50'
                 )}
               >
-                <Eye className="w-6 h-6" />
-                {t('home.quick.demos')}
+                <GraduationCap className="w-5 h-5" />
+                {t('home.viewCourse')}
               </Link>
             </div>
           </div>
         </div>
 
-        {/* Interactive Polarized Light Demo */}
-        <div className="mb-10">
-          <PolarizedLightHero height={200} className="shadow-2xl rounded-2xl" />
+        {/* 偏振光效果展示 */}
+        <div className="mb-8">
+          <PolarizedLightHero height={180} className="shadow-xl rounded-2xl" />
         </div>
 
-        {/* Learning Journey - Three Stages (简化预览，点击进入课程大纲) */}
+        {/* 快速入口 */}
+        <QuickAccessSection theme={theme} />
+
+        {/* 生活场景 */}
+        <LifeScenesSection theme={theme} />
+
+        {/* 课程大纲 - 5个单元 */}
         <div className="mb-8">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className={`text-lg font-bold ${
+          <div className="flex items-center gap-3 mb-4">
+            <div className="p-2 rounded-full bg-gradient-to-br from-cyan-400 to-blue-500">
+              <BookOpen className="w-4 h-4 text-white" />
+            </div>
+            <h2 className={cn(
+              'text-lg font-bold',
               theme === 'dark' ? 'text-white' : 'text-gray-900'
-            }`}>
-              {t('home.learningJourney')}
+            )}>
+              {t('home.courseOutline.title')}
             </h2>
-            <Link
-              to="/course"
-              className={`text-xs flex items-center gap-1 transition-colors ${
-                theme === 'dark'
-                  ? 'text-cyan-400 hover:text-cyan-300'
-                  : 'text-cyan-600 hover:text-cyan-700'
-              }`}
-            >
-              {t('home.viewAll')}
-              <ArrowRight className="w-3 h-3" />
-            </Link>
+            <span className={cn(
+              'text-[10px] px-2 py-0.5 rounded-full font-medium',
+              theme === 'dark'
+                ? 'bg-cyan-500/20 text-cyan-400'
+                : 'bg-cyan-100 text-cyan-700'
+            )}>
+              5 {t('home.courseOutline.units')}
+            </span>
           </div>
 
-          {/* Stage Cards - 水平排列的简化卡片 */}
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            {LEARNING_STAGES.map((stage) => (
-              <LearningStageCard
-                key={stage.id}
-                stage={stage}
+          <div className="space-y-3">
+            {COURSE_UNITS.map((unit) => (
+              <UnitCard
+                key={unit.id}
+                unit={unit}
                 theme={theme}
+                isExpanded={expandedUnitId === unit.id}
+                onToggle={() => handleToggleUnit(unit.id)}
                 completedDemos={progress.completedDemos}
               />
             ))}
           </div>
         </div>
 
-        {/* Life Scenes & Hands-on Experiments - Integrated Section */}
-        <LifeAndExperimentsSection theme={theme} />
-
-        {/* Quick Access Menu */}
-        <QuickAccessMenu theme={theme} />
-
-        {/* Course Outline - 详细课程大纲 */}
-        <CourseOutlineSection theme={theme} />
-
-        {/* Footer */}
-        <footer className={`mt-12 text-center text-xs ${
+        {/* 页脚 */}
+        <footer className={cn(
+          'mt-12 text-center text-xs',
           theme === 'dark' ? 'text-gray-600' : 'text-gray-500'
-        }`}>
-          <p className="opacity-60">© 2025 PolarCraft - A New World Under Polarized Light</p>
+        )}>
+          <p className="opacity-60">© 2025 PolarCraft - {t('home.title')}</p>
         </footer>
       </main>
-
-      {/* Guided Start Modal */}
-      {showGuidedStart && (
-        <GuidedStartModal
-          theme={theme}
-          onClose={handleGuidedClose}
-          onSelect={handleGuidedSelect}
-        />
-      )}
     </div>
   )
 }


### PR DESCRIPTION
- Replace 3-stage learning path with 5-unit PSRT course structure
- Integrate demos, optical studio experiments, chronicles, and games as resources within each course unit
- Add expandable unit cards with progress tracking
- Add quick access section for demos, optical studio, chronicles, calc
- Add life scenes section linking to relevant demos
- Reduce information overload through progressive disclosure design
- Add new translations for unit titles, sections, and resource types