### PR TITLE
Fix Atom reference error in HomePage

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -35,6 +35,8 @@ import {
   Compass,
   Target,
   Beaker,
+  Atom,
+  Wrench,
 } from 'lucide-react'
 
 // ============================================================================


### PR DESCRIPTION
The HomePage.tsx was referencing Atom and Wrench icons but they were not imported, causing a ReferenceError at runtime.