### PR TITLE
Redesign homepage with course outline and timeline

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -231,6 +231,86 @@
       "screenPolarizerDesc": "Rotate a polarizer over screen"
     },
     "keyExperiment": "Key Experiment",
+    "eras": {
+      "era1": {
+        "title": "Dawn of Discovery",
+        "subtitle": "Refraction, Prisms & Double Images",
+        "description": "In this pioneering era, scientists first discovered that light could be split and separated. Newton's prism revealed the spectrum, while Bartholin's calcite showed the mysterious double refraction—laying the foundation for understanding light's wave nature and polarization."
+      },
+      "era2": {
+        "title": "Golden Age of Polarization",
+        "subtitle": "Laws, Theories & Fundamental Discoveries",
+        "description": "The early 19th century saw an explosion of polarization discoveries. Malus found that reflected light is polarized, Brewster identified the polarization angle, and Fresnel proved light is a transverse wave. This era established most fundamental laws we still use today."
+      },
+      "era3": {
+        "title": "Mathematical Formalism",
+        "subtitle": "Stokes, Mueller & Quantitative Methods",
+        "description": "Scientists developed rigorous mathematical tools to describe polarization. Stokes parameters and Mueller matrices enabled complete characterization of any polarization state, while Rayleigh explained why the sky is blue through scattering theory."
+      },
+      "era4": {
+        "title": "Modern Applications",
+        "subtitle": "LCD Screens, Imaging & Beyond",
+        "description": "Polarization technology entered daily life through LCD displays and imaging systems. Full-polarization microscopy and remote sensing opened new frontiers in medicine, oceanography, and autonomous driving."
+      }
+    },
+    "discoveries": {
+      "snell": "Snell's Law of Refraction",
+      "newton": "Newton's Prism Experiment",
+      "bartholin": "Discovery of Birefringence",
+      "huygens": "Wave Theory of Light",
+      "malus": "Discovery of Polarization",
+      "arago": "Chromatic Polarization",
+      "brewster": "Brewster's Angle",
+      "biot": "Optical Rotation",
+      "fresnel": "Transverse Wave Theory",
+      "faraday": "Magneto-Optical Effect",
+      "pasteur": "Molecular Chirality",
+      "stokes": "Stokes Parameters",
+      "rayleigh": "Rayleigh Scattering",
+      "poincare": "Poincaré Sphere",
+      "polaroid": "Polaroid Film",
+      "jones": "Jones Calculus",
+      "mueller": "Mueller Matrices",
+      "laser": "First Laser",
+      "lcd": "LCD Technology",
+      "polarimetry": "Polarimetric Imaging"
+    },
+    "scientists": {
+      "snell": "Willebrord Snell",
+      "newton": "Isaac Newton",
+      "bartholin": "Rasmus Bartholin",
+      "huygens": "Christiaan Huygens",
+      "malus": "Étienne-Louis Malus",
+      "arago": "François Arago",
+      "brewster": "David Brewster",
+      "biot": "Jean-Baptiste Biot",
+      "fresnel": "Augustin-Jean Fresnel",
+      "faraday": "Michael Faraday",
+      "pasteur": "Louis Pasteur",
+      "stokes": "George Stokes",
+      "rayleigh": "Lord Rayleigh",
+      "poincare": "Henri Poincaré",
+      "land": "Edwin Land",
+      "jones": "R. Clark Jones",
+      "mueller": "Hans Mueller",
+      "maiman": "Theodore Maiman",
+      "lcd": "Various Inventors",
+      "modern": "Modern Researchers"
+    },
+    "links": {
+      "birefringence": "Birefringence Demo",
+      "lightWave": "Light Wave",
+      "malus": "Malus's Law",
+      "brewster": "Brewster's Angle",
+      "opticalStudio": "Optical Studio",
+      "game2d": "2D Puzzle Game",
+      "rayleigh": "Rayleigh Scattering",
+      "stokes": "Stokes Vector",
+      "poincare": "Poincaré Sphere",
+      "calc": "Calculation Tools",
+      "microscopy": "Polarimetric Microscopy",
+      "mueller": "Mueller Matrix"
+    },
     "resType": {
       "demo": "Demo",
       "experiment": "Exp",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -231,6 +231,86 @@
       "screenPolarizerDesc": "在屏幕前旋转偏振片"
     },
     "keyExperiment": "核心实验",
+    "eras": {
+      "era1": {
+        "title": "发现之初",
+        "subtitle": "折射、棱镜与双像",
+        "description": "在这个开创性的时代，科学家们首次发现光可以被分离和分解。牛顿的棱镜实验揭示了光谱的秘密，而巴多林的冰洲石展示了神秘的双折射现象——为理解光的波动性和偏振奠定了基础。"
+      },
+      "era2": {
+        "title": "偏振黄金时代",
+        "subtitle": "定律、理论与基础发现",
+        "description": "19世纪初见证了偏振发现的爆发。马吕斯发现反射光是偏振的，布儒斯特确定了偏振角，菲涅尔证明了光是横波。这个时代建立了我们今天仍在使用的大部分基本定律。"
+      },
+      "era3": {
+        "title": "数学形式化",
+        "subtitle": "斯托克斯、穆勒与定量方法",
+        "description": "科学家们发展出严格的数学工具来描述偏振。斯托克斯参数和穆勒矩阵能够完整表征任何偏振态，而瑞利通过散射理论解释了为什么天空是蓝色的。"
+      },
+      "era4": {
+        "title": "现代应用",
+        "subtitle": "LCD屏幕、成像及更多",
+        "description": "偏振技术通过液晶显示器和成像系统进入日常生活。全偏振显微镜和遥感技术在医学、海洋学和自动驾驶领域开辟了新前沿。"
+      }
+    },
+    "discoveries": {
+      "snell": "斯涅尔折射定律",
+      "newton": "牛顿棱镜实验",
+      "bartholin": "双折射的发现",
+      "huygens": "光的波动理论",
+      "malus": "偏振现象的发现",
+      "arago": "色偏振",
+      "brewster": "布儒斯特角",
+      "biot": "旋光现象",
+      "fresnel": "横波理论",
+      "faraday": "磁光效应",
+      "pasteur": "分子手性",
+      "stokes": "斯托克斯参数",
+      "rayleigh": "瑞利散射",
+      "poincare": "庞加莱球",
+      "polaroid": "宝丽来偏光片",
+      "jones": "Jones矩阵方法",
+      "mueller": "Mueller矩阵",
+      "laser": "第一台激光器",
+      "lcd": "液晶显示技术",
+      "polarimetry": "偏振成像技术"
+    },
+    "scientists": {
+      "snell": "威理博·斯涅尔",
+      "newton": "艾萨克·牛顿",
+      "bartholin": "拉斯穆·巴多林",
+      "huygens": "克里斯蒂安·惠更斯",
+      "malus": "艾蒂安-路易·马吕斯",
+      "arago": "弗朗索瓦·阿拉戈",
+      "brewster": "大卫·布儒斯特",
+      "biot": "让-巴蒂斯特·毕奥",
+      "fresnel": "奥古斯丁-让·菲涅尔",
+      "faraday": "迈克尔·法拉第",
+      "pasteur": "路易·巴斯德",
+      "stokes": "乔治·斯托克斯",
+      "rayleigh": "瑞利勋爵",
+      "poincare": "亨利·庞加莱",
+      "land": "埃德温·兰德",
+      "jones": "R·克拉克·琼斯",
+      "mueller": "汉斯·穆勒",
+      "maiman": "西奥多·梅曼",
+      "lcd": "多位发明家",
+      "modern": "现代研究者"
+    },
+    "links": {
+      "birefringence": "双折射演示",
+      "lightWave": "光波演示",
+      "malus": "马吕斯定律",
+      "brewster": "布儒斯特角",
+      "opticalStudio": "光学设计室",
+      "game2d": "2D解谜游戏",
+      "rayleigh": "瑞利散射",
+      "stokes": "Stokes矢量",
+      "poincare": "庞加莱球",
+      "calc": "计算工具",
+      "microscopy": "偏振显微镜",
+      "mueller": "Mueller矩阵"
+    },
     "resType": {
       "demo": "演示",
       "experiment": "实验",

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,29 +1,29 @@
 /**
- * HomePage - PSRT Course Homepage
- * 首页 - 以五单元课程大纲为主框架
+ * HomePage - Chronicles of Light (光的编年史)
+ * 首页 - 以历史时间线为主框架，融合课程大纲
  *
- * 架构：以PSRT课程大纲的5个单元为核心展开
- * 将"偏振演示馆"、"光学设计室"、"光的编年史"融合到每个单元中
- * 采用探索和游戏化模式，避免信息过载
+ * 设计理念：
+ * 1. 以编年史时间线为核心叙事结构
+ * 2. 将5个课程单元嵌入对应的历史时期
+ * 3. 每个时代展示关键发现，并连接到相关学习资源
+ * 4. 提供沉浸式的光学历史探索体验
  */
 
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { LanguageThemeSwitcher } from '@/components/ui/LanguageThemeSwitcher'
 import { useTheme } from '@/contexts/ThemeContext'
 import { PolarWorldLogo } from '@/components/icons'
 import { PolarizedLightHero } from '@/components/effects'
-import { useCourseProgress } from '@/hooks'
 import { cn } from '@/lib/utils'
 import {
   Play,
   Lightbulb,
   BookOpen,
-  FlaskConical,
-  ArrowRight,
   Eye,
   ChevronDown,
+  ChevronRight,
   Sparkles,
   Zap,
   Microscope,
@@ -34,415 +34,307 @@ import {
   Calculator,
   Compass,
   Target,
-  Beaker,
+  Clock,
+  GraduationCap,
+  Telescope,
   Atom,
   Wrench,
+  ExternalLink,
 } from 'lucide-react'
 
 // ============================================================================
-// 课程大纲数据结构 - 5个单元
+// 时代定义 - 编年史主框架
 // ============================================================================
 
-interface UnitResource {
-  type: 'demo' | 'experiment' | 'history' | 'game' | 'tool'
+interface HistoricalEra {
   id: string
-  titleKey: string
-  link: string
-  icon?: React.ReactNode
-}
-
-interface CourseSection {
-  id: string
-  titleKey: string
-  descKey: string
-  resources: UnitResource[]
-}
-
-interface CourseUnit {
-  id: string
-  number: number
+  yearStart: number
+  yearEnd: number
   titleKey: string
   subtitleKey: string
   descriptionKey: string
-  icon: React.ReactNode
   color: string
   gradient: string
-  bgPattern: string
-  sections: CourseSection[]
-  keyExperiment?: {
+  bgGlow: string
+  icon: React.ReactNode
+  // 该时代的关键发现
+  keyDiscoveries: {
+    year: number
+    titleKey: string
+    scientistKey: string
+    importance: 1 | 2 | 3
+    track: 'optics' | 'polarization'
+    link?: string
+  }[]
+  // 关联的课程单元
+  courseUnits: number[]
+  // 推荐入口
+  featuredLinks: {
+    type: 'demo' | 'experiment' | 'game' | 'tool'
     titleKey: string
     link: string
-  }
+    icon: React.ReactNode
+  }[]
 }
 
-// 5个单元课程数据
-const COURSE_UNITS: CourseUnit[] = [
+const HISTORICAL_ERAS: HistoricalEra[] = [
   {
-    // 第一单元：光的偏振态及其调制和测量
-    id: 'unit1',
-    number: 1,
-    titleKey: 'home.units.unit1.title',
-    subtitleKey: 'home.units.unit1.subtitle',
-    descriptionKey: 'home.units.unit1.description',
-    icon: <Lightbulb className="w-5 h-5" />,
+    id: 'era1',
+    yearStart: 1621,
+    yearEnd: 1700,
+    titleKey: 'home.eras.era1.title',
+    subtitleKey: 'home.eras.era1.subtitle',
+    descriptionKey: 'home.eras.era1.description',
+    color: '#C9A227',
+    gradient: 'from-amber-600 to-yellow-500',
+    bgGlow: 'rgba(201, 162, 39, 0.15)',
+    icon: <Sparkles className="w-5 h-5" />,
+    keyDiscoveries: [
+      { year: 1621, titleKey: 'home.discoveries.snell', scientistKey: 'home.scientists.snell', importance: 1, track: 'optics' },
+      { year: 1665, titleKey: 'home.discoveries.newton', scientistKey: 'home.scientists.newton', importance: 1, track: 'optics', link: '/demos/light-wave' },
+      { year: 1669, titleKey: 'home.discoveries.bartholin', scientistKey: 'home.scientists.bartholin', importance: 1, track: 'polarization', link: '/demos/birefringence' },
+      { year: 1690, titleKey: 'home.discoveries.huygens', scientistKey: 'home.scientists.huygens', importance: 1, track: 'optics' },
+    ],
+    courseUnits: [1],
+    featuredLinks: [
+      { type: 'demo', titleKey: 'home.links.birefringence', link: '/demos/birefringence', icon: <Layers className="w-4 h-4" /> },
+      { type: 'demo', titleKey: 'home.links.lightWave', link: '/demos/light-wave', icon: <Sparkles className="w-4 h-4" /> },
+    ],
+  },
+  {
+    id: 'era2',
+    yearStart: 1800,
+    yearEnd: 1850,
+    titleKey: 'home.eras.era2.title',
+    subtitleKey: 'home.eras.era2.subtitle',
+    descriptionKey: 'home.eras.era2.description',
     color: '#22D3EE',
     gradient: 'from-cyan-500 to-blue-500',
-    bgPattern: 'radial-gradient(circle at 20% 80%, rgba(34, 211, 238, 0.1) 0%, transparent 50%)',
-    keyExperiment: {
-      titleKey: 'home.units.unit1.keyExp',
-      link: '/demos/birefringence',
-    },
-    sections: [
-      {
-        id: '1.1',
-        titleKey: 'home.units.unit1.s1.title',
-        descKey: 'home.units.unit1.s1.desc',
-        resources: [
-          { type: 'demo', id: 'light-wave', titleKey: 'home.res.lightWave', link: '/demos/light-wave', icon: <Sparkles className="w-4 h-4" /> },
-          { type: 'demo', id: 'polarization-intro', titleKey: 'home.res.polarIntro', link: '/demos/polarization-intro', icon: <Eye className="w-4 h-4" /> },
-        ],
-      },
-      {
-        id: '1.2',
-        titleKey: 'home.units.unit1.s2.title',
-        descKey: 'home.units.unit1.s2.desc',
-        resources: [
-          { type: 'demo', id: 'birefringence', titleKey: 'home.res.birefringence', link: '/demos/birefringence', icon: <Layers className="w-4 h-4" /> },
-          { type: 'history', id: 'calcite-history', titleKey: 'home.res.calciteHistory', link: '/chronicles?topic=calcite', icon: <History className="w-4 h-4" /> },
-        ],
-      },
-      {
-        id: '1.3',
-        titleKey: 'home.units.unit1.s3.title',
-        descKey: 'home.units.unit1.s3.desc',
-        resources: [
-          { type: 'demo', id: 'malus', titleKey: 'home.res.malus', link: '/demos/malus', icon: <Target className="w-4 h-4" /> },
-          { type: 'experiment', id: 'malus-exp', titleKey: 'home.res.malusExp', link: '/optical-studio?exp=malus', icon: <FlaskConical className="w-4 h-4" /> },
-          { type: 'history', id: 'malus-history', titleKey: 'home.res.malusHistory', link: '/chronicles?topic=malus', icon: <History className="w-4 h-4" /> },
-          { type: 'game', id: 'game-level0', titleKey: 'home.res.gameLevel0', link: '/games/2d?level=0', icon: <Gamepad2 className="w-4 h-4" /> },
-        ],
-      },
+    bgGlow: 'rgba(34, 211, 238, 0.15)',
+    icon: <Zap className="w-5 h-5" />,
+    keyDiscoveries: [
+      { year: 1808, titleKey: 'home.discoveries.malus', scientistKey: 'home.scientists.malus', importance: 1, track: 'polarization', link: '/demos/malus' },
+      { year: 1811, titleKey: 'home.discoveries.arago', scientistKey: 'home.scientists.arago', importance: 2, track: 'polarization', link: '/demos/chromatic' },
+      { year: 1812, titleKey: 'home.discoveries.brewster', scientistKey: 'home.scientists.brewster', importance: 1, track: 'polarization', link: '/demos/brewster' },
+      { year: 1815, titleKey: 'home.discoveries.biot', scientistKey: 'home.scientists.biot', importance: 2, track: 'polarization', link: '/demos/optical-rotation' },
+      { year: 1817, titleKey: 'home.discoveries.fresnel', scientistKey: 'home.scientists.fresnel', importance: 1, track: 'optics', link: '/demos/fresnel' },
+      { year: 1845, titleKey: 'home.discoveries.faraday', scientistKey: 'home.scientists.faraday', importance: 1, track: 'polarization' },
+      { year: 1848, titleKey: 'home.discoveries.pasteur', scientistKey: 'home.scientists.pasteur', importance: 2, track: 'polarization' },
+    ],
+    courseUnits: [1, 2, 3],
+    featuredLinks: [
+      { type: 'demo', titleKey: 'home.links.malus', link: '/demos/malus', icon: <Target className="w-4 h-4" /> },
+      { type: 'demo', titleKey: 'home.links.brewster', link: '/demos/brewster', icon: <Zap className="w-4 h-4" /> },
+      { type: 'experiment', titleKey: 'home.links.opticalStudio', link: '/optical-studio', icon: <Wrench className="w-4 h-4" /> },
+      { type: 'game', titleKey: 'home.links.game2d', link: '/games/2d', icon: <Gamepad2 className="w-4 h-4" /> },
     ],
   },
   {
-    // 第二单元：界面反射的偏振特征
-    id: 'unit2',
-    number: 2,
-    titleKey: 'home.units.unit2.title',
-    subtitleKey: 'home.units.unit2.subtitle',
-    descriptionKey: 'home.units.unit2.description',
-    icon: <Zap className="w-5 h-5" />,
+    id: 'era3',
+    yearStart: 1850,
+    yearEnd: 1950,
+    titleKey: 'home.eras.era3.title',
+    subtitleKey: 'home.eras.era3.subtitle',
+    descriptionKey: 'home.eras.era3.description',
     color: '#A78BFA',
     gradient: 'from-violet-500 to-purple-500',
-    bgPattern: 'radial-gradient(circle at 80% 20%, rgba(167, 139, 250, 0.1) 0%, transparent 50%)',
-    keyExperiment: {
-      titleKey: 'home.units.unit2.keyExp',
-      link: '/demos/brewster',
-    },
-    sections: [
-      {
-        id: '2.1',
-        titleKey: 'home.units.unit2.s1.title',
-        descKey: 'home.units.unit2.s1.desc',
-        resources: [
-          { type: 'demo', id: 'fresnel', titleKey: 'home.res.fresnel', link: '/demos/fresnel', icon: <Sparkles className="w-4 h-4" /> },
-        ],
-      },
-      {
-        id: '2.2',
-        titleKey: 'home.units.unit2.s2.title',
-        descKey: 'home.units.unit2.s2.desc',
-        resources: [
-          { type: 'demo', id: 'brewster', titleKey: 'home.res.brewster', link: '/demos/brewster', icon: <Zap className="w-4 h-4" /> },
-          { type: 'experiment', id: 'brewster-exp', titleKey: 'home.res.brewsterExp', link: '/optical-studio?exp=brewster', icon: <FlaskConical className="w-4 h-4" /> },
-        ],
-      },
+    bgGlow: 'rgba(167, 139, 250, 0.15)',
+    icon: <Atom className="w-5 h-5" />,
+    keyDiscoveries: [
+      { year: 1852, titleKey: 'home.discoveries.stokes', scientistKey: 'home.scientists.stokes', importance: 1, track: 'polarization', link: '/demos/stokes' },
+      { year: 1871, titleKey: 'home.discoveries.rayleigh', scientistKey: 'home.scientists.rayleigh', importance: 1, track: 'polarization', link: '/demos/rayleigh' },
+      { year: 1892, titleKey: 'home.discoveries.poincare', scientistKey: 'home.scientists.poincare', importance: 2, track: 'polarization', link: '/calc/poincare' },
+      { year: 1929, titleKey: 'home.discoveries.polaroid', scientistKey: 'home.scientists.land', importance: 1, track: 'polarization' },
+      { year: 1941, titleKey: 'home.discoveries.jones', scientistKey: 'home.scientists.jones', importance: 2, track: 'polarization', link: '/demos/jones' },
+      { year: 1943, titleKey: 'home.discoveries.mueller', scientistKey: 'home.scientists.mueller', importance: 2, track: 'polarization', link: '/demos/mueller' },
+    ],
+    courseUnits: [4, 5],
+    featuredLinks: [
+      { type: 'demo', titleKey: 'home.links.rayleigh', link: '/demos/rayleigh', icon: <Sun className="w-4 h-4" /> },
+      { type: 'demo', titleKey: 'home.links.stokes', link: '/demos/stokes', icon: <Target className="w-4 h-4" /> },
+      { type: 'tool', titleKey: 'home.links.poincare', link: '/calc/poincare', icon: <Compass className="w-4 h-4" /> },
+      { type: 'tool', titleKey: 'home.links.calc', link: '/calc', icon: <Calculator className="w-4 h-4" /> },
     ],
   },
   {
-    // 第三单元：透明介质的偏振特征
-    id: 'unit3',
-    number: 3,
-    titleKey: 'home.units.unit3.title',
-    subtitleKey: 'home.units.unit3.subtitle',
-    descriptionKey: 'home.units.unit3.description',
-    icon: <Layers className="w-5 h-5" />,
-    color: '#F59E0B',
-    gradient: 'from-amber-500 to-orange-500',
-    bgPattern: 'radial-gradient(circle at 50% 50%, rgba(245, 158, 11, 0.1) 0%, transparent 50%)',
-    keyExperiment: {
-      titleKey: 'home.units.unit3.keyExp',
-      link: '/demos/chromatic',
-    },
-    sections: [
-      {
-        id: '3.1',
-        titleKey: 'home.units.unit3.s1.title',
-        descKey: 'home.units.unit3.s1.desc',
-        resources: [
-          { type: 'demo', id: 'chromatic', titleKey: 'home.res.chromatic', link: '/demos/chromatic', icon: <Sparkles className="w-4 h-4" /> },
-          { type: 'demo', id: 'anisotropy', titleKey: 'home.res.anisotropy', link: '/demos/anisotropy', icon: <Layers className="w-4 h-4" /> },
-          { type: 'experiment', id: 'stress-exp', titleKey: 'home.res.stressExp', link: '/optical-studio?exp=stress', icon: <FlaskConical className="w-4 h-4" /> },
-        ],
-      },
-      {
-        id: '3.2',
-        titleKey: 'home.units.unit3.s2.title',
-        descKey: 'home.units.unit3.s2.desc',
-        resources: [
-          { type: 'demo', id: 'optical-rotation', titleKey: 'home.res.opticalRotation', link: '/demos/optical-rotation', icon: <Compass className="w-4 h-4" /> },
-          { type: 'experiment', id: 'sugar-exp', titleKey: 'home.res.sugarExp', link: '/experiments?exp=sugar', icon: <Beaker className="w-4 h-4" /> },
-        ],
-      },
-    ],
-  },
-  {
-    // 第四单元：浑浊介质的偏振特征
-    id: 'unit4',
-    number: 4,
-    titleKey: 'home.units.unit4.title',
-    subtitleKey: 'home.units.unit4.subtitle',
-    descriptionKey: 'home.units.unit4.description',
-    icon: <Sun className="w-5 h-5" />,
+    id: 'era4',
+    yearStart: 1950,
+    yearEnd: 2025,
+    titleKey: 'home.eras.era4.title',
+    subtitleKey: 'home.eras.era4.subtitle',
+    descriptionKey: 'home.eras.era4.description',
     color: '#EC4899',
     gradient: 'from-pink-500 to-rose-500',
-    bgPattern: 'radial-gradient(circle at 30% 70%, rgba(236, 72, 153, 0.1) 0%, transparent 50%)',
-    keyExperiment: {
-      titleKey: 'home.units.unit4.keyExp',
-      link: '/demos/rayleigh',
-    },
-    sections: [
-      {
-        id: '4.1',
-        titleKey: 'home.units.unit4.s1.title',
-        descKey: 'home.units.unit4.s1.desc',
-        resources: [
-          { type: 'demo', id: 'rayleigh', titleKey: 'home.res.rayleigh', link: '/demos/rayleigh', icon: <Sun className="w-4 h-4" /> },
-          { type: 'demo', id: 'mie', titleKey: 'home.res.mie', link: '/demos/mie-scattering', icon: <Atom className="w-4 h-4" /> },
-        ],
-      },
-      {
-        id: '4.2',
-        titleKey: 'home.units.unit4.s2.title',
-        descKey: 'home.units.unit4.s2.desc',
-        resources: [
-          { type: 'demo', id: 'monte-carlo', titleKey: 'home.res.monteCarlo', link: '/demos/monte-carlo-scattering', icon: <Sparkles className="w-4 h-4" /> },
-        ],
-      },
-    ],
-  },
-  {
-    // 第五单元：全偏振光学技术
-    id: 'unit5',
-    number: 5,
-    titleKey: 'home.units.unit5.title',
-    subtitleKey: 'home.units.unit5.subtitle',
-    descriptionKey: 'home.units.unit5.description',
+    bgGlow: 'rgba(236, 72, 153, 0.15)',
     icon: <Microscope className="w-5 h-5" />,
-    color: '#8B5CF6',
-    gradient: 'from-violet-600 to-indigo-600',
-    bgPattern: 'radial-gradient(circle at 70% 30%, rgba(139, 92, 246, 0.1) 0%, transparent 50%)',
-    keyExperiment: {
-      titleKey: 'home.units.unit5.keyExp',
-      link: '/demos/mueller',
-    },
-    sections: [
-      {
-        id: '5.1',
-        titleKey: 'home.units.unit5.s1.title',
-        descKey: 'home.units.unit5.s1.desc',
-        resources: [
-          { type: 'demo', id: 'stokes', titleKey: 'home.res.stokes', link: '/demos/stokes', icon: <Target className="w-4 h-4" /> },
-          { type: 'demo', id: 'mueller', titleKey: 'home.res.mueller', link: '/demos/mueller', icon: <Layers className="w-4 h-4" /> },
-          { type: 'tool', id: 'stokes-calc', titleKey: 'home.res.stokesCalc', link: '/calc/stokes', icon: <Calculator className="w-4 h-4" /> },
-          { type: 'tool', id: 'mueller-calc', titleKey: 'home.res.muellerCalc', link: '/calc/mueller', icon: <Calculator className="w-4 h-4" /> },
-        ],
-      },
-      {
-        id: '5.2',
-        titleKey: 'home.units.unit5.s2.title',
-        descKey: 'home.units.unit5.s2.desc',
-        resources: [
-          { type: 'demo', id: 'jones', titleKey: 'home.res.jones', link: '/demos/jones', icon: <Sparkles className="w-4 h-4" /> },
-          { type: 'tool', id: 'jones-calc', titleKey: 'home.res.jonesCalc', link: '/calc/jones', icon: <Calculator className="w-4 h-4" /> },
-          { type: 'tool', id: 'poincare', titleKey: 'home.res.poincare', link: '/calc/poincare', icon: <Compass className="w-4 h-4" /> },
-        ],
-      },
-      {
-        id: '5.3',
-        titleKey: 'home.units.unit5.s3.title',
-        descKey: 'home.units.unit5.s3.desc',
-        resources: [
-          { type: 'demo', id: 'microscopy', titleKey: 'home.res.microscopy', link: '/demos/polarimetric-microscopy', icon: <Microscope className="w-4 h-4" /> },
-        ],
-      },
+    keyDiscoveries: [
+      { year: 1960, titleKey: 'home.discoveries.laser', scientistKey: 'home.scientists.maiman', importance: 1, track: 'optics' },
+      { year: 1971, titleKey: 'home.discoveries.lcd', scientistKey: 'home.scientists.lcd', importance: 1, track: 'polarization' },
+      { year: 2018, titleKey: 'home.discoveries.polarimetry', scientistKey: 'home.scientists.modern', importance: 2, track: 'polarization', link: '/demos/polarimetric-microscopy' },
+    ],
+    courseUnits: [5],
+    featuredLinks: [
+      { type: 'demo', titleKey: 'home.links.microscopy', link: '/demos/polarimetric-microscopy', icon: <Microscope className="w-4 h-4" /> },
+      { type: 'demo', titleKey: 'home.links.mueller', link: '/demos/mueller', icon: <Layers className="w-4 h-4" /> },
     ],
   },
+]
+
+// ============================================================================
+// 课程单元数据 (简化版，用于时间线嵌入)
+// ============================================================================
+
+interface CourseUnitBrief {
+  id: number
+  titleKey: string
+  subtitleKey: string
+  icon: React.ReactNode
+  color: string
+  mainDemo: string
+  gameLevel?: string
+}
+
+const COURSE_UNITS_BRIEF: CourseUnitBrief[] = [
+  { id: 1, titleKey: 'home.units.unit1.title', subtitleKey: 'home.units.unit1.subtitle', icon: <Lightbulb className="w-4 h-4" />, color: '#C9A227', mainDemo: '/demos/birefringence', gameLevel: '/games/2d?level=0' },
+  { id: 2, titleKey: 'home.units.unit2.title', subtitleKey: 'home.units.unit2.subtitle', icon: <Zap className="w-4 h-4" />, color: '#6366F1', mainDemo: '/demos/brewster' },
+  { id: 3, titleKey: 'home.units.unit3.title', subtitleKey: 'home.units.unit3.subtitle', icon: <Sparkles className="w-4 h-4" />, color: '#0891B2', mainDemo: '/demos/chromatic', gameLevel: '/games/2d?level=3' },
+  { id: 4, titleKey: 'home.units.unit4.title', subtitleKey: 'home.units.unit4.subtitle', icon: <Target className="w-4 h-4" />, color: '#F59E0B', mainDemo: '/demos/rayleigh' },
+  { id: 5, titleKey: 'home.units.unit5.title', subtitleKey: 'home.units.unit5.subtitle', icon: <Telescope className="w-4 h-4" />, color: '#8B5CF6', mainDemo: '/demos/mueller' },
 ]
 
 // ============================================================================
 // 动态背景组件
 // ============================================================================
 
-function PolarizationBackground({ theme }: { theme: 'dark' | 'light' }) {
+function TimelineBackground({ theme }: { theme: 'dark' | 'light' }) {
   const [time, setTime] = useState(0)
 
   useEffect(() => {
     const interval = setInterval(() => {
-      setTime(t => (t + 1) % 360)
+      setTime(t => (t + 0.5) % 360)
     }, 50)
     return () => clearInterval(interval)
   }, [])
 
   return (
     <div className="fixed inset-0 pointer-events-none overflow-hidden">
+      {/* 旋转光晕 */}
       <div
-        className="absolute inset-0"
+        className="absolute inset-0 opacity-30"
         style={{
           background: theme === 'dark'
-            ? `conic-gradient(from ${time}deg at 50% 50%,
-                rgba(34, 211, 238, 0.03) 0deg,
-                rgba(167, 139, 250, 0.03) 120deg,
-                rgba(139, 92, 246, 0.03) 240deg,
-                rgba(34, 211, 238, 0.03) 360deg)`
-            : `conic-gradient(from ${time}deg at 50% 50%,
-                rgba(34, 211, 238, 0.02) 0deg,
-                rgba(167, 139, 250, 0.02) 120deg,
-                rgba(139, 92, 246, 0.02) 240deg,
-                rgba(34, 211, 238, 0.02) 360deg)`,
+            ? `conic-gradient(from ${time}deg at 30% 30%, rgba(201, 162, 39, 0.1) 0deg, transparent 90deg, rgba(34, 211, 238, 0.1) 180deg, transparent 270deg, rgba(201, 162, 39, 0.1) 360deg)`
+            : `conic-gradient(from ${time}deg at 30% 30%, rgba(201, 162, 39, 0.05) 0deg, transparent 90deg, rgba(34, 211, 238, 0.05) 180deg, transparent 270deg, rgba(201, 162, 39, 0.05) 360deg)`,
         }}
+      />
+      {/* 垂直时间线光带 */}
+      <div
+        className={cn(
+          'absolute left-1/2 top-0 bottom-0 w-px -translate-x-1/2',
+          theme === 'dark'
+            ? 'bg-gradient-to-b from-transparent via-amber-500/20 to-transparent'
+            : 'bg-gradient-to-b from-transparent via-amber-400/10 to-transparent'
+        )}
       />
     </div>
   )
 }
 
 // ============================================================================
-// 资源类型标签组件
+// 时代卡片组件
 // ============================================================================
 
-function ResourceBadge({ type, theme }: { type: UnitResource['type']; theme: 'dark' | 'light' }) {
-  const { t } = useTranslation()
-
-  const config = {
-    demo: { color: '#22D3EE', labelKey: 'home.resType.demo' },
-    experiment: { color: '#F59E0B', labelKey: 'home.resType.experiment' },
-    history: { color: '#C9A227', labelKey: 'home.resType.history' },
-    game: { color: '#EC4899', labelKey: 'home.resType.game' },
-    tool: { color: '#8B5CF6', labelKey: 'home.resType.tool' },
-  }
-
-  const cfg = config[type]
-
-  return (
-    <span
-      className="text-[9px] px-1.5 py-0.5 rounded font-medium"
-      style={{
-        backgroundColor: `${cfg.color}20`,
-        color: cfg.color,
-      }}
-    >
-      {t(cfg.labelKey)}
-    </span>
-  )
-}
-
-// ============================================================================
-// 单元卡片组件
-// ============================================================================
-
-function UnitCard({
-  unit,
+function EraCard({
+  era,
   theme,
   isExpanded,
   onToggle,
-  completedDemos,
+  isZh,
 }: {
-  unit: CourseUnit
+  era: HistoricalEra
   theme: 'dark' | 'light'
   isExpanded: boolean
   onToggle: () => void
-  completedDemos: string[]
+  isZh: boolean
 }) {
   const { t } = useTranslation()
 
-  // 计算进度
-  const allResources = unit.sections.flatMap(s => s.resources.filter(r => r.type === 'demo'))
-  const completedCount = allResources.filter(r => completedDemos.includes(r.id)).length
-  const progressPercent = allResources.length > 0 ? Math.round((completedCount / allResources.length) * 100) : 0
+  // 获取关联的课程单元
+  const relatedUnits = COURSE_UNITS_BRIEF.filter(u => era.courseUnits.includes(u.id))
 
   return (
     <div
       className={cn(
-        'rounded-2xl border overflow-hidden transition-all duration-300',
+        'relative rounded-2xl border overflow-hidden transition-all duration-500',
         theme === 'dark'
-          ? 'bg-slate-800/60 border-slate-700/50'
-          : 'bg-white/90 border-gray-200'
+          ? 'bg-slate-800/70 border-slate-700/50 backdrop-blur-sm'
+          : 'bg-white/90 border-gray-200 backdrop-blur-sm'
       )}
       style={{
-        borderColor: isExpanded ? unit.color : undefined,
-        boxShadow: isExpanded ? `0 4px 30px ${unit.color}20` : undefined,
-        background: isExpanded ? unit.bgPattern : undefined,
+        borderColor: isExpanded ? era.color : undefined,
+        boxShadow: isExpanded
+          ? `0 8px 40px ${era.bgGlow}, inset 0 1px 0 rgba(255,255,255,0.1)`
+          : undefined,
       }}
     >
-      {/* 单元头部 - 可点击展开 */}
+      {/* 时代头部 */}
       <button
         className={cn(
-          'w-full p-4 flex items-center gap-4 text-left transition-colors',
+          'w-full p-5 flex items-center gap-4 text-left transition-colors',
           theme === 'dark' ? 'hover:bg-slate-700/30' : 'hover:bg-gray-50'
         )}
         onClick={onToggle}
       >
-        {/* 单元编号 */}
+        {/* 年代标记 */}
         <div
           className={cn(
-            'flex-shrink-0 w-12 h-12 rounded-xl flex items-center justify-center bg-gradient-to-br shadow-lg',
-            unit.gradient
+            'flex-shrink-0 w-16 h-16 rounded-xl flex flex-col items-center justify-center bg-gradient-to-br shadow-lg',
+            era.gradient
           )}
         >
-          <span className="text-white text-xl font-bold">{unit.number}</span>
+          <span className="text-white text-xl font-bold">{era.yearStart}</span>
+          <span className="text-white/70 text-[10px]">—{era.yearEnd}</span>
         </div>
 
-        {/* 单元信息 */}
+        {/* 时代信息 */}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1">
+            <span style={{ color: era.color }}>{era.icon}</span>
             <h3 className={cn(
-              'text-base font-bold truncate',
+              'text-lg font-bold truncate',
               theme === 'dark' ? 'text-white' : 'text-gray-900'
             )}>
-              {t(unit.titleKey)}
+              {t(era.titleKey)}
             </h3>
           </div>
           <p className={cn(
-            'text-sm truncate',
+            'text-sm',
             theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
           )}>
-            {t(unit.subtitleKey)}
+            {t(era.subtitleKey)}
           </p>
 
-          {/* 进度条 */}
-          <div className="mt-2 flex items-center gap-2">
-            <div className={cn(
-              'flex-1 h-1 rounded-full',
-              theme === 'dark' ? 'bg-slate-700' : 'bg-gray-200'
-            )}>
-              <div
-                className={cn('h-full rounded-full bg-gradient-to-r transition-all', unit.gradient)}
-                style={{ width: `${progressPercent}%` }}
-              />
-            </div>
-            <span className={cn(
-              'text-[10px] font-medium',
-              theme === 'dark' ? 'text-gray-500' : 'text-gray-400'
-            )}>
-              {completedCount}/{allResources.length}
-            </span>
+          {/* 课程单元标签 */}
+          <div className="flex flex-wrap gap-1.5 mt-2">
+            {relatedUnits.map(unit => (
+              <span
+                key={unit.id}
+                className="text-[10px] px-2 py-0.5 rounded-full font-medium"
+                style={{
+                  backgroundColor: `${unit.color}20`,
+                  color: unit.color,
+                }}
+              >
+                {isZh ? `第${unit.id}单元` : `Unit ${unit.id}`}
+              </span>
+            ))}
           </div>
         </div>
 
         {/* 展开指示器 */}
         <ChevronDown
           className={cn(
-            'w-5 h-5 flex-shrink-0 transition-transform duration-300',
+            'w-6 h-6 flex-shrink-0 transition-transform duration-300',
             isExpanded ? 'rotate-180' : '',
             theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
           )}
@@ -452,90 +344,196 @@ function UnitCard({
       {/* 展开内容 */}
       {isExpanded && (
         <div className={cn(
-          'px-4 pb-4 border-t',
+          'px-5 pb-5 border-t',
           theme === 'dark' ? 'border-slate-700/50' : 'border-gray-100'
         )}>
-          {/* 单元描述 */}
+          {/* 时代描述 */}
           <p className={cn(
-            'text-sm mt-3 mb-4',
+            'text-sm mt-4 mb-5 leading-relaxed',
             theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
           )}>
-            {t(unit.descriptionKey)}
+            {t(era.descriptionKey)}
           </p>
 
-          {/* 核心实验入口 */}
-          {unit.keyExperiment && (
-            <Link
-              to={unit.keyExperiment.link}
-              className={cn(
-                'flex items-center gap-3 p-3 rounded-xl mb-4 transition-all hover:scale-[1.01]',
-                'bg-gradient-to-r text-white shadow-lg',
-                unit.gradient
-              )}
-            >
-              <div className="p-2 bg-white/20 rounded-lg">
-                <FlaskConical className="w-5 h-5" />
-              </div>
-              <div className="flex-1">
-                <p className="text-xs opacity-80">{t('home.keyExperiment')}</p>
-                <p className="font-medium">{t(unit.keyExperiment.titleKey)}</p>
-              </div>
-              <ArrowRight className="w-5 h-5" />
-            </Link>
-          )}
-
-          {/* 各小节内容 */}
-          <div className="space-y-4">
-            {unit.sections.map((section) => (
-              <div key={section.id}>
-                {/* 小节标题 */}
-                <div className="flex items-center gap-2 mb-2">
+          {/* 关键发现时间线 */}
+          <div className="mb-5">
+            <h4 className={cn(
+              'text-xs font-semibold uppercase tracking-wider mb-3 flex items-center gap-2',
+              theme === 'dark' ? 'text-gray-500' : 'text-gray-400'
+            )}>
+              <History className="w-3.5 h-3.5" />
+              {isZh ? '关键发现' : 'Key Discoveries'}
+            </h4>
+            <div className="space-y-2">
+              {era.keyDiscoveries.map((discovery, idx) => (
+                <div
+                  key={idx}
+                  className={cn(
+                    'flex items-center gap-3 p-2.5 rounded-lg transition-colors',
+                    theme === 'dark'
+                      ? 'bg-slate-700/30 hover:bg-slate-700/50'
+                      : 'bg-gray-50 hover:bg-gray-100'
+                  )}
+                >
+                  {/* 年份 */}
                   <span
-                    className="text-xs font-bold px-2 py-0.5 rounded"
-                    style={{ backgroundColor: `${unit.color}20`, color: unit.color }}
+                    className={cn(
+                      'text-xs font-mono font-bold px-2 py-0.5 rounded',
+                      discovery.track === 'optics'
+                        ? theme === 'dark' ? 'bg-amber-500/20 text-amber-400' : 'bg-amber-100 text-amber-700'
+                        : theme === 'dark' ? 'bg-cyan-500/20 text-cyan-400' : 'bg-cyan-100 text-cyan-700'
+                    )}
                   >
-                    {section.id}
+                    {discovery.year}
                   </span>
-                  <h4 className={cn(
-                    'text-sm font-semibold',
-                    theme === 'dark' ? 'text-white' : 'text-gray-900'
-                  )}>
-                    {t(section.titleKey)}
-                  </h4>
-                </div>
-                <p className={cn(
-                  'text-xs mb-2',
-                  theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
-                )}>
-                  {t(section.descKey)}
-                </p>
 
-                {/* 资源列表 */}
-                <div className="flex flex-wrap gap-2">
-                  {section.resources.map((resource) => (
+                  {/* 发现内容 */}
+                  <div className="flex-1 min-w-0">
+                    <p className={cn(
+                      'text-sm font-medium truncate',
+                      theme === 'dark' ? 'text-white' : 'text-gray-900'
+                    )}>
+                      {t(discovery.titleKey)}
+                    </p>
+                    <p className={cn(
+                      'text-xs truncate',
+                      theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+                    )}>
+                      {t(discovery.scientistKey)}
+                    </p>
+                  </div>
+
+                  {/* 重要性标记 */}
+                  <div className="flex gap-0.5">
+                    {[1, 2, 3].map(i => (
+                      <div
+                        key={i}
+                        className={cn(
+                          'w-1.5 h-1.5 rounded-full',
+                          i <= discovery.importance
+                            ? discovery.track === 'optics'
+                              ? 'bg-amber-500'
+                              : 'bg-cyan-500'
+                            : theme === 'dark' ? 'bg-slate-600' : 'bg-gray-300'
+                        )}
+                      />
+                    ))}
+                  </div>
+
+                  {/* 链接 */}
+                  {discovery.link && (
                     <Link
-                      key={resource.id}
-                      to={resource.link}
+                      to={discovery.link}
                       className={cn(
-                        'group flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-all hover:scale-105',
+                        'p-1.5 rounded-lg transition-colors',
                         theme === 'dark'
-                          ? 'bg-slate-700/50 hover:bg-slate-700'
-                          : 'bg-gray-50 hover:bg-gray-100'
+                          ? 'hover:bg-slate-600 text-gray-400 hover:text-white'
+                          : 'hover:bg-gray-200 text-gray-400 hover:text-gray-700'
                       )}
                     >
-                      <span style={{ color: unit.color }}>{resource.icon}</span>
-                      <span className={cn(
-                        'font-medium',
-                        theme === 'dark' ? 'text-white' : 'text-gray-700'
-                      )}>
-                        {t(resource.titleKey)}
-                      </span>
-                      <ResourceBadge type={resource.type} theme={theme} />
+                      <ExternalLink className="w-3.5 h-3.5" />
                     </Link>
-                  ))}
+                  )}
                 </div>
+              ))}
+            </div>
+          </div>
+
+          {/* 关联课程单元 */}
+          {relatedUnits.length > 0 && (
+            <div className="mb-5">
+              <h4 className={cn(
+                'text-xs font-semibold uppercase tracking-wider mb-3 flex items-center gap-2',
+                theme === 'dark' ? 'text-gray-500' : 'text-gray-400'
+              )}>
+                <GraduationCap className="w-3.5 h-3.5" />
+                {isZh ? '关联课程' : 'Related Course Units'}
+              </h4>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {relatedUnits.map(unit => (
+                  <Link
+                    key={unit.id}
+                    to={unit.mainDemo}
+                    className={cn(
+                      'flex items-center gap-3 p-3 rounded-xl transition-all hover:scale-[1.02]',
+                      theme === 'dark'
+                        ? 'bg-slate-700/50 hover:bg-slate-700'
+                        : 'bg-gray-50 hover:bg-gray-100'
+                    )}
+                  >
+                    <div
+                      className="w-8 h-8 rounded-lg flex items-center justify-center"
+                      style={{ backgroundColor: `${unit.color}20` }}
+                    >
+                      <span style={{ color: unit.color }}>{unit.icon}</span>
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className={cn(
+                        'text-sm font-medium truncate',
+                        theme === 'dark' ? 'text-white' : 'text-gray-900'
+                      )}>
+                        {t(unit.titleKey)}
+                      </p>
+                      <p className={cn(
+                        'text-[10px] truncate',
+                        theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+                      )}>
+                        {t(unit.subtitleKey)}
+                      </p>
+                    </div>
+                    <ChevronRight className={cn(
+                      'w-4 h-4 flex-shrink-0',
+                      theme === 'dark' ? 'text-gray-500' : 'text-gray-400'
+                    )} />
+                  </Link>
+                ))}
               </div>
-            ))}
+            </div>
+          )}
+
+          {/* 推荐入口 */}
+          <div>
+            <h4 className={cn(
+              'text-xs font-semibold uppercase tracking-wider mb-3 flex items-center gap-2',
+              theme === 'dark' ? 'text-gray-500' : 'text-gray-400'
+            )}>
+              <Eye className="w-3.5 h-3.5" />
+              {isZh ? '探索体验' : 'Explore & Learn'}
+            </h4>
+            <div className="flex flex-wrap gap-2">
+              {era.featuredLinks.map((link, idx) => (
+                <Link
+                  key={idx}
+                  to={link.link}
+                  className={cn(
+                    'flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-all hover:scale-105',
+                    theme === 'dark'
+                      ? 'bg-slate-700/50 hover:bg-slate-700'
+                      : 'bg-gray-50 hover:bg-gray-100'
+                  )}
+                >
+                  <span style={{ color: era.color }}>{link.icon}</span>
+                  <span className={cn(
+                    'font-medium',
+                    theme === 'dark' ? 'text-white' : 'text-gray-700'
+                  )}>
+                    {t(link.titleKey)}
+                  </span>
+                  <span
+                    className="text-[9px] px-1.5 py-0.5 rounded font-medium"
+                    style={{
+                      backgroundColor: link.type === 'demo' ? '#22D3EE20' : link.type === 'experiment' ? '#F59E0B20' : link.type === 'game' ? '#EC489920' : '#8B5CF620',
+                      color: link.type === 'demo' ? '#22D3EE' : link.type === 'experiment' ? '#F59E0B' : link.type === 'game' ? '#EC4899' : '#8B5CF6',
+                    }}
+                  >
+                    {link.type === 'demo' ? (isZh ? '演示' : 'Demo') :
+                     link.type === 'experiment' ? (isZh ? '实验' : 'Exp') :
+                     link.type === 'game' ? (isZh ? '游戏' : 'Game') :
+                     (isZh ? '工具' : 'Tool')}
+                  </span>
+                </Link>
+              ))}
+            </div>
           </div>
         </div>
       )}
@@ -544,117 +542,88 @@ function UnitCard({
 }
 
 // ============================================================================
-// 快速入口组件
+// 快速导航栏
 // ============================================================================
 
-function QuickAccessSection({ theme }: { theme: 'dark' | 'light' }) {
-  const { t } = useTranslation()
-
-  const quickLinks = [
-    { icon: <Eye className="w-5 h-5" />, labelKey: 'home.quick.demos', link: '/demos', color: '#22D3EE' },
-    { icon: <Wrench className="w-5 h-5" />, labelKey: 'home.quick.opticalStudio', link: '/optical-studio', color: '#F59E0B' },
-    { icon: <History className="w-5 h-5" />, labelKey: 'home.quick.chronicles', link: '/chronicles', color: '#C9A227' },
-    { icon: <Calculator className="w-5 h-5" />, labelKey: 'home.quick.calc', link: '/calc', color: '#8B5CF6' },
+function QuickNav({ theme, isZh }: { theme: 'dark' | 'light'; isZh: boolean }) {
+  const navItems = [
+    { icon: <Eye className="w-5 h-5" />, label: isZh ? '演示馆' : 'Demos', link: '/demos', color: '#22D3EE' },
+    { icon: <Wrench className="w-5 h-5" />, label: isZh ? '设计室' : 'Studio', link: '/optical-studio', color: '#F59E0B' },
+    { icon: <Gamepad2 className="w-5 h-5" />, label: isZh ? '游戏' : 'Games', link: '/games', color: '#EC4899' },
+    { icon: <Calculator className="w-5 h-5" />, label: isZh ? '计算' : 'Calc', link: '/calc', color: '#8B5CF6' },
+    { icon: <History className="w-5 h-5" />, label: isZh ? '编年史' : 'Timeline', link: '/chronicles', color: '#C9A227' },
   ]
 
   return (
     <div className={cn(
-      'rounded-xl p-4 mb-6',
+      'flex justify-center gap-2 sm:gap-4 p-3 rounded-2xl mb-6',
       theme === 'dark' ? 'bg-slate-800/50' : 'bg-white/80'
     )}>
-      <h3 className={cn(
-        'text-sm font-semibold mb-3',
-        theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
-      )}>
-        {t('home.quickAccess')}
-      </h3>
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-        {quickLinks.map((item, idx) => (
-          <Link
-            key={idx}
-            to={item.link}
-            className={cn(
-              'flex flex-col items-center gap-2 p-4 rounded-xl transition-all hover:scale-105',
-              theme === 'dark'
-                ? 'bg-slate-700/50 hover:bg-slate-700'
-                : 'bg-gray-50 hover:bg-gray-100'
-            )}
+      {navItems.map((item, idx) => (
+        <Link
+          key={idx}
+          to={item.link}
+          className={cn(
+            'flex flex-col items-center gap-1.5 px-3 sm:px-4 py-2 rounded-xl transition-all hover:scale-110',
+            theme === 'dark' ? 'hover:bg-slate-700/50' : 'hover:bg-gray-100'
+          )}
+        >
+          <div
+            className="w-10 h-10 rounded-xl flex items-center justify-center"
+            style={{ backgroundColor: `${item.color}20` }}
           >
-            <div
-              className="w-10 h-10 rounded-xl flex items-center justify-center"
-              style={{ backgroundColor: `${item.color}20` }}
-            >
-              <span style={{ color: item.color }}>{item.icon}</span>
-            </div>
-            <span className={cn(
-              'text-xs font-medium text-center',
-              theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
-            )}>
-              {t(item.labelKey)}
-            </span>
-          </Link>
-        ))}
-      </div>
+            <span style={{ color: item.color }}>{item.icon}</span>
+          </div>
+          <span className={cn(
+            'text-[10px] sm:text-xs font-medium',
+            theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
+          )}>
+            {item.label}
+          </span>
+        </Link>
+      ))}
     </div>
   )
 }
 
 // ============================================================================
-// 生活场景卡片
+// 生活场景入口
 // ============================================================================
 
-function LifeScenesSection({ theme }: { theme: 'dark' | 'light' }) {
-  const { t } = useTranslation()
-
+function LifeScenesBar({ theme, isZh }: { theme: 'dark' | 'light'; isZh: boolean }) {
   const scenes = [
-    { emoji: '🌅', titleKey: 'home.life.sky', descKey: 'home.life.skyDesc', link: '/demos/rayleigh', color: '#F59E0B' },
-    { emoji: '📱', titleKey: 'home.life.screen', descKey: 'home.life.screenDesc', link: '/demos/polarization-intro', color: '#3B82F6' },
-    { emoji: '🕶️', titleKey: 'home.life.sunglasses', descKey: 'home.life.sunglassesDesc', link: '/demos/malus', color: '#8B5CF6' },
-    { emoji: '🦋', titleKey: 'home.life.butterfly', descKey: 'home.life.butterflyDesc', link: '/demos/chromatic', color: '#EC4899' },
+    { emoji: '🌅', label: isZh ? '蓝天红霞' : 'Sky Colors', link: '/demos/rayleigh' },
+    { emoji: '📱', label: isZh ? 'LCD屏幕' : 'LCD Screen', link: '/demos/polarization-intro' },
+    { emoji: '🕶️', label: isZh ? '偏光眼镜' : 'Sunglasses', link: '/demos/malus' },
+    { emoji: '🦋', label: isZh ? '彩色蝴蝶' : 'Butterfly', link: '/demos/chromatic' },
   ]
 
   return (
     <div className={cn(
-      'rounded-xl p-4 mb-6',
-      theme === 'dark' ? 'bg-slate-800/50' : 'bg-white/80'
+      'flex flex-wrap justify-center gap-2 mb-6',
+      theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
     )}>
-      <h3 className={cn(
-        'text-sm font-semibold mb-3 flex items-center gap-2',
-        theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
-      )}>
-        <Compass className="w-4 h-4 text-cyan-500" />
-        {t('home.lifeTitle')}
-      </h3>
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-        {scenes.map((scene, idx) => (
-          <Link
-            key={idx}
-            to={scene.link}
-            className={cn(
-              'group flex items-center gap-2 p-3 rounded-lg transition-all hover:scale-[1.02]',
-              theme === 'dark'
-                ? 'bg-slate-700/50 hover:bg-slate-700'
-                : 'bg-gray-50 hover:bg-gray-100'
-            )}
-          >
-            <span className="text-2xl">{scene.emoji}</span>
-            <div className="flex-1 min-w-0">
-              <p className={cn(
-                'text-xs font-medium truncate',
-                theme === 'dark' ? 'text-white' : 'text-gray-900'
-              )}>
-                {t(scene.titleKey)}
-              </p>
-              <p className={cn(
-                'text-[10px] truncate',
-                theme === 'dark' ? 'text-gray-400' : 'text-gray-500'
-              )}>
-                {t(scene.descKey)}
-              </p>
-            </div>
-          </Link>
-        ))}
-      </div>
+      <span className="text-xs self-center mr-1">{isZh ? '生活中的偏振：' : 'Polarization in Life:'}</span>
+      {scenes.map((scene, idx) => (
+        <Link
+          key={idx}
+          to={scene.link}
+          className={cn(
+            'flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm transition-all hover:scale-105',
+            theme === 'dark'
+              ? 'bg-slate-800/50 hover:bg-slate-700/50'
+              : 'bg-white/80 hover:bg-gray-100'
+          )}
+        >
+          <span>{scene.emoji}</span>
+          <span className={cn(
+            'text-xs font-medium',
+            theme === 'dark' ? 'text-gray-300' : 'text-gray-700'
+          )}>
+            {scene.label}
+          </span>
+        </Link>
+      ))}
     </div>
   )
 }
@@ -664,54 +633,31 @@ function LifeScenesSection({ theme }: { theme: 'dark' | 'light' }) {
 // ============================================================================
 
 export function HomePage() {
-  const { t } = useTranslation()
+  const { i18n } = useTranslation()
   const { theme } = useTheme()
   const navigate = useNavigate()
-  const { progress } = useCourseProgress()
+  const isZh = i18n.language === 'zh'
 
-  // 展开状态管理
-  const [expandedUnitId, setExpandedUnitId] = useState<string | null>(null)
+  // 展开状态
+  const [expandedEraId, setExpandedEraId] = useState<string | null>('era2') // 默认展开黄金时代
 
-  // 首个未完成单元自动展开
-  useEffect(() => {
-    const firstIncomplete = COURSE_UNITS.find(unit => {
-      const demos = unit.sections.flatMap(s => s.resources.filter(r => r.type === 'demo'))
-      return demos.some(d => !progress.completedDemos.includes(d.id))
-    })
-    if (firstIncomplete && !expandedUnitId) {
-      setExpandedUnitId(firstIncomplete.id)
-    }
-  }, [progress.completedDemos])
-
-  const handleToggleUnit = useCallback((unitId: string) => {
-    setExpandedUnitId(prev => prev === unitId ? null : unitId)
+  const handleToggleEra = useCallback((eraId: string) => {
+    setExpandedEraId(prev => prev === eraId ? null : eraId)
   }, [])
 
   const handleStartLearning = useCallback(() => {
-    // 跳转到第一个未完成的演示
-    for (const unit of COURSE_UNITS) {
-      for (const section of unit.sections) {
-        for (const resource of section.resources) {
-          if (resource.type === 'demo' && !progress.completedDemos.includes(resource.id)) {
-            navigate(resource.link)
-            return
-          }
-        }
-      }
-    }
-    // 如果全部完成，跳转到第一个演示
     navigate('/demos/polarization-intro')
-  }, [navigate, progress.completedDemos])
+  }, [navigate])
 
   return (
     <div className={cn(
       'min-h-screen',
       theme === 'dark'
         ? 'bg-gradient-to-br from-[#0a0a1a] via-[#1a1a3a] to-[#0a0a2a]'
-        : 'bg-gradient-to-br from-[#f0f9ff] via-[#e0f2fe] to-[#f0f9ff]'
+        : 'bg-gradient-to-br from-[#fffbeb] via-[#fef3c7] to-[#f0f9ff]'
     )}>
       {/* 动态背景 */}
-      <PolarizationBackground theme={theme} />
+      <TimelineBackground theme={theme} />
 
       {/* 顶部导航 */}
       <header className="fixed top-0 left-0 right-0 z-50">
@@ -726,10 +672,10 @@ export function HomePage() {
             <span className={cn(
               'hidden sm:block font-bold text-base',
               theme === 'dark'
-                ? 'text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 to-violet-400'
-                : 'text-transparent bg-clip-text bg-gradient-to-r from-cyan-600 to-violet-600'
+                ? 'text-transparent bg-clip-text bg-gradient-to-r from-amber-400 to-cyan-400'
+                : 'text-transparent bg-clip-text bg-gradient-to-r from-amber-600 to-cyan-600'
             )}>
-              偏振光下的新世界
+              {isZh ? '偏振光下的新世界' : 'A New World Under Polarized Light'}
             </span>
           </div>
           <LanguageThemeSwitcher />
@@ -745,39 +691,42 @@ export function HomePage() {
             <div className={cn(
               'absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] rounded-full blur-[100px]',
               theme === 'dark'
-                ? 'bg-gradient-to-r from-cyan-500/20 via-blue-500/15 to-violet-500/20'
-                : 'bg-gradient-to-r from-cyan-400/15 via-blue-400/10 to-violet-400/15'
+                ? 'bg-gradient-to-r from-amber-500/20 via-transparent to-cyan-500/20'
+                : 'bg-gradient-to-r from-amber-400/15 via-transparent to-cyan-400/15'
             )} />
           </div>
 
           {/* 标题 */}
           <div className="text-center pt-6 pb-4">
             <div className="flex items-center justify-center gap-2 mb-3">
+              <Clock className={cn('w-4 h-4', theme === 'dark' ? 'text-amber-400' : 'text-amber-600')} />
               <span className={cn(
                 'text-xs px-3 py-1 rounded-full font-medium',
                 theme === 'dark'
-                  ? 'bg-cyan-500/20 text-cyan-400'
-                  : 'bg-cyan-100 text-cyan-700'
+                  ? 'bg-amber-500/20 text-amber-400'
+                  : 'bg-amber-100 text-amber-700'
               )}>
-                {t('home.courseBanner.badge')}
+                {isZh ? '光的编年史 · P-SRT课程' : 'Chronicles of Light · P-SRT Course'}
               </span>
             </div>
 
             <h1 className={cn(
-              'text-4xl sm:text-5xl font-black tracking-tight mb-4',
+              'text-3xl sm:text-4xl md:text-5xl font-black tracking-tight mb-4',
               'text-transparent bg-clip-text',
               theme === 'dark'
-                ? 'bg-gradient-to-br from-white via-cyan-200 to-violet-300'
-                : 'bg-gradient-to-br from-gray-900 via-cyan-700 to-violet-700'
+                ? 'bg-gradient-to-br from-amber-300 via-white to-cyan-300'
+                : 'bg-gradient-to-br from-amber-700 via-gray-900 to-cyan-700'
             )}>
-              {t('home.title')}
+              {isZh ? '偏振光下的新世界' : 'A New World Under Polarized Light'}
             </h1>
 
             <p className={cn(
               'text-base sm:text-lg max-w-2xl mx-auto mb-6',
               theme === 'dark' ? 'text-gray-400' : 'text-gray-600'
             )}>
-              {t('home.courseBanner.description')}
+              {isZh
+                ? '从1669年冰洲石的意外发现，到现代全偏振成像技术——跟随历史的脚步，探索三百五十年的光学奥秘'
+                : 'From the accidental discovery of Iceland spar in 1669 to modern polarimetric imaging — follow history\'s footsteps through 350 years of optical mysteries'}
             </p>
 
             {/* CTA 按钮 */}
@@ -786,26 +735,26 @@ export function HomePage() {
                 onClick={handleStartLearning}
                 className={cn(
                   'group px-6 py-3 rounded-full font-bold flex items-center gap-2',
-                  'bg-gradient-to-r from-cyan-500 via-blue-500 to-violet-500 text-white',
+                  'bg-gradient-to-r from-amber-500 via-orange-500 to-cyan-500 text-white',
                   'hover:scale-105 transition-all duration-300',
-                  'shadow-lg shadow-blue-500/30 hover:shadow-xl hover:shadow-blue-500/40'
+                  'shadow-lg shadow-orange-500/30 hover:shadow-xl hover:shadow-orange-500/40'
                 )}
               >
                 <Play className="w-5 h-5 group-hover:scale-110 transition-transform" />
-                {t('home.startLearning')}
+                {isZh ? '开始探索' : 'Start Exploring'}
               </button>
               <Link
-                to="/demos"
+                to="/chronicles"
                 className={cn(
                   'px-6 py-3 rounded-full font-bold flex items-center gap-2',
                   'border-2 transition-all duration-300 hover:scale-105',
                   theme === 'dark'
-                    ? 'border-slate-600 text-gray-300 hover:border-slate-500 hover:bg-slate-800/50'
-                    : 'border-gray-300 text-gray-700 hover:border-gray-400 hover:bg-gray-50'
+                    ? 'border-amber-500/50 text-amber-400 hover:border-amber-400 hover:bg-amber-500/10'
+                    : 'border-amber-400 text-amber-700 hover:border-amber-500 hover:bg-amber-50'
                 )}
               >
-                <Eye className="w-5 h-5" />
-                {t('home.explore')}
+                <History className="w-5 h-5" />
+                {isZh ? '完整时间线' : 'Full Timeline'}
               </Link>
             </div>
           </div>
@@ -813,48 +762,75 @@ export function HomePage() {
 
         {/* 偏振光效果展示 */}
         <div className="mb-8">
-          <PolarizedLightHero height={180} className="shadow-xl rounded-2xl" />
+          <PolarizedLightHero height={160} className="shadow-xl rounded-2xl" />
         </div>
 
-        {/* 快速入口 */}
-        <QuickAccessSection theme={theme} />
+        {/* 快速导航 */}
+        <QuickNav theme={theme} isZh={isZh} />
 
         {/* 生活场景 */}
-        <LifeScenesSection theme={theme} />
+        <LifeScenesBar theme={theme} isZh={isZh} />
 
-        {/* 课程大纲 - 5个单元 */}
+        {/* 编年史时间线 - 核心内容 */}
         <div className="mb-8">
-          <div className="flex items-center gap-3 mb-4">
-            <div className="p-2 rounded-full bg-gradient-to-br from-cyan-400 to-blue-500">
+          <div className="flex items-center gap-3 mb-5">
+            <div className="p-2 rounded-full bg-gradient-to-br from-amber-400 to-cyan-500">
               <BookOpen className="w-4 h-4 text-white" />
             </div>
-            <h2 className={cn(
-              'text-lg font-bold',
-              theme === 'dark' ? 'text-white' : 'text-gray-900'
-            )}>
-              {t('home.courseOutline.title')}
-            </h2>
-            <span className={cn(
-              'text-[10px] px-2 py-0.5 rounded-full font-medium',
-              theme === 'dark'
-                ? 'bg-cyan-500/20 text-cyan-400'
-                : 'bg-cyan-100 text-cyan-700'
-            )}>
-              5 {t('home.courseOutline.units')}
-            </span>
+            <div>
+              <h2 className={cn(
+                'text-lg font-bold',
+                theme === 'dark' ? 'text-white' : 'text-gray-900'
+              )}>
+                {isZh ? '光的编年史' : 'Chronicles of Light'}
+              </h2>
+              <p className={cn(
+                'text-xs',
+                theme === 'dark' ? 'text-gray-500' : 'text-gray-500'
+              )}>
+                {isZh ? '从17世纪到现代 · 5个课程单元' : 'From 17th Century to Modern Day · 5 Course Units'}
+              </p>
+            </div>
+            <div className="flex items-center gap-2 ml-auto">
+              <span className={cn(
+                'flex items-center gap-1 text-[10px] px-2 py-1 rounded-full',
+                theme === 'dark' ? 'bg-amber-500/20 text-amber-400' : 'bg-amber-100 text-amber-700'
+              )}>
+                <Sun className="w-3 h-3" />
+                {isZh ? '光学' : 'Optics'}
+              </span>
+              <span className={cn(
+                'flex items-center gap-1 text-[10px] px-2 py-1 rounded-full',
+                theme === 'dark' ? 'bg-cyan-500/20 text-cyan-400' : 'bg-cyan-100 text-cyan-700'
+              )}>
+                <Sparkles className="w-3 h-3" />
+                {isZh ? '偏振' : 'Polarization'}
+              </span>
+            </div>
           </div>
 
-          <div className="space-y-3">
-            {COURSE_UNITS.map((unit) => (
-              <UnitCard
-                key={unit.id}
-                unit={unit}
-                theme={theme}
-                isExpanded={expandedUnitId === unit.id}
-                onToggle={() => handleToggleUnit(unit.id)}
-                completedDemos={progress.completedDemos}
-              />
-            ))}
+          {/* 时代卡片列表 */}
+          <div className="relative">
+            {/* 时间线连接线 */}
+            <div className={cn(
+              'absolute left-8 top-0 bottom-0 w-0.5',
+              theme === 'dark'
+                ? 'bg-gradient-to-b from-amber-500/50 via-cyan-500/30 to-purple-500/50'
+                : 'bg-gradient-to-b from-amber-300 via-cyan-300 to-purple-300'
+            )} />
+
+            <div className="space-y-4 relative">
+              {HISTORICAL_ERAS.map((era) => (
+                <EraCard
+                  key={era.id}
+                  era={era}
+                  theme={theme}
+                  isExpanded={expandedEraId === era.id}
+                  onToggle={() => handleToggleEra(era.id)}
+                  isZh={isZh}
+                />
+              ))}
+            </div>
           </div>
         </div>
 
@@ -863,7 +839,9 @@ export function HomePage() {
           'mt-12 text-center text-xs',
           theme === 'dark' ? 'text-gray-600' : 'text-gray-500'
         )}>
-          <p className="opacity-60">© 2025 深圳零一学院 · {t('home.title')}</p>
+          <p className="opacity-60">
+            © 2025 {isZh ? '深圳零一学院' : 'Shenzhen Academy 01'} · {isZh ? '偏振光下的新世界' : 'A New World Under Polarized Light'}
+          </p>
         </footer>
       </main>
     </div>


### PR DESCRIPTION
- Restructure homepage around historical eras (1621-2025)
- Embed 5 course units into corresponding historical periods
- Add 4 chronological era cards with expandable content
- Include key discoveries timeline with scientist names
- Add quick navigation bar for main platform sections
- Add life scenes shortcuts (Sky Colors, LCD, Sunglasses, etc.)
- Add bilingual translations for eras, discoveries, and scientists
- Integrate course units with related demos and experiments