### PR TITLE
Fix routing errors across pages and modules

### DIFF
--- a/src/components/museum/MuseumHomepage.tsx
+++ b/src/components/museum/MuseumHomepage.tsx
@@ -846,7 +846,7 @@ function QuickStartSection() {
       titleKey: 'museum.quickStart.challenge.title',
       descriptionKey: 'museum.quickStart.challenge.description',
       color: '#f59e0b',
-      action: () => navigate('/game2d')
+      action: () => navigate('/games/2d')
     }
   ]
 
@@ -1210,7 +1210,7 @@ function MuseumFooter() {
               </li>
               <li>
                 <button
-                  onClick={() => navigate('/game2d')}
+                  onClick={() => navigate('/games/2d')}
                   className={cn(
                     "text-sm hover:underline",
                     theme === 'dark' ? "text-slate-400 hover:text-white" : "text-slate-600 hover:text-slate-900"

--- a/src/components/shared/PolarizationComparison.tsx
+++ b/src/components/shared/PolarizationComparison.tsx
@@ -19,7 +19,6 @@ import {
   Play,
   Pause,
   RotateCcw,
-  Info,
   ChevronRight,
   Waves,
   Eye,

--- a/src/data/chronicles-constants.ts
+++ b/src/data/chronicles-constants.ts
@@ -87,14 +87,14 @@ export const ILLUSTRATION_TO_DEMO_MAP: Record<string, { route: string; labelEn: 
 // Optical bench experiment mappings for "复现实验" button
 // 用于"在实验室复现"按钮的光学工作台实验映射
 export const ILLUSTRATION_TO_BENCH_MAP: Record<string, { route: string; labelEn: string; labelZh: string }> = {
-  'polarizer': { route: '/bench?experiment=malus-law', labelEn: 'Recreate in Lab', labelZh: '在实验室复现' },
-  'malus': { route: '/bench?experiment=malus-law', labelEn: 'Recreate in Lab', labelZh: '在实验室复现' },
-  'birefringence': { route: '/bench?experiment=birefringence', labelEn: 'Recreate in Lab', labelZh: '在实验室复现' },
-  'calcite': { route: '/bench?experiment=birefringence', labelEn: 'Recreate in Lab', labelZh: '在实验室复现' },
-  'nicol': { route: '/bench?experiment=birefringence', labelEn: 'Recreate in Lab', labelZh: '在实验室复现' },
-  'chromaticpol': { route: '/bench?experiment=chromatic-polarization', labelEn: 'Recreate in Lab', labelZh: '在实验室复现' },
-  'faraday': { route: '/bench?experiment=faraday-rotation', labelEn: 'Recreate in Lab', labelZh: '在实验室复现' },
-  'opticalactivity': { route: '/bench?experiment=optical-rotation', labelEn: 'Recreate in Lab', labelZh: '在实验室复现' },
+  'polarizer': { route: '/optical-studio?experiment=malus-law', labelEn: 'Recreate in Lab', labelZh: '在实验室复现' },
+  'malus': { route: '/optical-studio?experiment=malus-law', labelEn: 'Recreate in Lab', labelZh: '在实验室复现' },
+  'birefringence': { route: '/optical-studio?experiment=birefringence', labelEn: 'Recreate in Lab', labelZh: '在实验室复现' },
+  'calcite': { route: '/optical-studio?experiment=birefringence', labelEn: 'Recreate in Lab', labelZh: '在实验室复现' },
+  'nicol': { route: '/optical-studio?experiment=birefringence', labelEn: 'Recreate in Lab', labelZh: '在实验室复现' },
+  'chromaticpol': { route: '/optical-studio?experiment=chromatic-polarization', labelEn: 'Recreate in Lab', labelZh: '在实验室复现' },
+  'faraday': { route: '/optical-studio?experiment=faraday-rotation', labelEn: 'Recreate in Lab', labelZh: '在实验室复现' },
+  'opticalactivity': { route: '/optical-studio?experiment=optical-rotation', labelEn: 'Recreate in Lab', labelZh: '在实验室复现' },
 }
 
 // Type exports for external use

--- a/src/pages/DetectiveGamePage.tsx
+++ b/src/pages/DetectiveGamePage.tsx
@@ -454,7 +454,7 @@ export function DetectiveGamePage() {
           <div className="flex items-center gap-2">
             {/* Back button */}
             <Link
-              to="/game2d"
+              to="/games/2d"
               className={cn(
                 'p-2 rounded-lg transition-all',
                 isDark ? 'hover:bg-slate-700/50 text-slate-400' : 'hover:bg-slate-200 text-slate-600'

--- a/src/pages/ExperimentsPage.tsx
+++ b/src/pages/ExperimentsPage.tsx
@@ -531,7 +531,7 @@ export function ExperimentsPage() {
                   </div>
                 </Link>
                 <Link
-                  to="/devices"
+                  to="/optical-studio"
                   className={cn(
                     'p-4 rounded-lg flex items-start gap-3 transition-colors',
                     theme === 'dark'
@@ -550,7 +550,7 @@ export function ExperimentsPage() {
                   </div>
                 </Link>
                 <Link
-                  to="/bench"
+                  to="/optical-studio"
                   className={cn(
                     'p-4 rounded-lg flex items-start gap-3 transition-colors',
                     theme === 'dark'

--- a/src/pages/Game2DPage.tsx
+++ b/src/pages/Game2DPage.tsx
@@ -817,7 +817,7 @@ export function Game2DPage() {
             {!isCompact && (
               <>
                 <Link
-                  to="/game"
+                  to="/games/3d"
                   className={cn(
                     'p-2 rounded-lg transition-colors',
                     isDark ? 'hover:bg-slate-800 text-slate-300' : 'hover:bg-slate-200 text-slate-600'

--- a/src/pages/LabPage.tsx
+++ b/src/pages/LabPage.tsx
@@ -297,7 +297,7 @@ const ANALYSIS_TOOLS: AnalysisTool[] = [
     descriptionZh: '从强度测量计算和可视化斯托克斯参数。',
     icon: <Calculator className="w-5 h-5" />,
     available: true,
-    link: '/lab/stokes',
+    link: '/calc/stokes',
   },
   {
     id: 'mueller-sim',
@@ -307,7 +307,7 @@ const ANALYSIS_TOOLS: AnalysisTool[] = [
     descriptionZh: '使用穆勒矩阵计算斯托克斯矢量变换，支持部分偏振光。',
     icon: <BarChart3 className="w-5 h-5" />,
     available: true,
-    link: '/lab/mueller',
+    link: '/calc/mueller',
   },
   {
     id: 'jones-calc',
@@ -317,7 +317,7 @@ const ANALYSIS_TOOLS: AnalysisTool[] = [
     descriptionZh: '计算完全偏振光的琼斯向量变换。',
     icon: <Calculator className="w-5 h-5" />,
     available: true,
-    link: '/lab/jones',
+    link: '/calc/jones',
   },
   {
     id: 'data-fitting',
@@ -336,7 +336,7 @@ const ANALYSIS_TOOLS: AnalysisTool[] = [
     descriptionZh: '在庞加莱球上可视化偏振态。',
     icon: <Sparkles className="w-5 h-5" />,
     available: true,
-    link: '/lab/poincare',
+    link: '/calc/poincare',
   },
 ]
 


### PR DESCRIPTION
- Update /lab/* links to /calc/* in LabPage.tsx
- Update /bench to /optical-studio in chronicles-constants.ts
- Update /game2d to /games/2d in MuseumHomepage.tsx and DetectiveGamePage.tsx
- Update /game to /games/3d in Game2DPage.tsx
- Update /devices and /bench to /optical-studio in ExperimentsPage.tsx
- Remove unused 'Info' import in PolarizationComparison.tsx

These changes ensure all navigation links use the correct routes after the route restructuring that added legacy redirects.