### PR TITLE
Fix message connection error in background script

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { resolve } from 'path';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
-  base: './', // Use relative paths for IPFS/decentralized hosting compatibility
+  base: '/', // Use absolute paths for SPA routing compatibility
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),


### PR DESCRIPTION
Change base from './' to '/' to fix module loading errors on nested routes. Relative paths caused browsers to resolve assets incorrectly when refreshing on routes like /demos/, resulting in MIME type errors.