### PR TITLE
Fix polarization gallery difficulty labels display

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1022,10 +1022,14 @@
       "foundation": "Foundation",
       "application": "Application",
       "research": "Research",
+      "explore": "Explore",
+      "professional": "Professional",
       "foundationDesc": "PSRT: Discover light's mysteries in simple terms - no formulas needed!",
       "applicationDesc": "ESRT: Hands-on experiments with key formulas and concepts",
       "researchDesc": "ORIC/SURF: Rigorous academic treatment with research perspective",
-      "formulaHidden": "Want formulas? Switch to Application or Research mode"
+      "exploreDesc": "Discover the mysteries of polarized light intuitively - perfect for beginners",
+      "professionalDesc": "In-depth professional knowledge with mathematical formulas and research-level content",
+      "formulaHidden": "Want formulas? Switch to Professional mode"
     },
     "questions": {
       "title": "Think Before You Explore",
@@ -1069,10 +1073,14 @@
       "foundation": "Foundation",
       "application": "Application",
       "research": "Research",
+      "explore": "Explore",
+      "professional": "Professional",
       "foundationDesc": "PSRT: Discover light's mysteries in simple terms - no formulas needed!",
       "applicationDesc": "ESRT: Hands-on experiments with key formulas and concepts",
       "researchDesc": "ORIC/SURF: Rigorous academic treatment with research perspective",
-      "formulaHidden": "Want formulas? Switch to Application or Research mode"
+      "exploreDesc": "Discover the mysteries of polarized light intuitively - perfect for beginners",
+      "professionalDesc": "In-depth professional knowledge with mathematical formulas and research-level content",
+      "formulaHidden": "Want formulas? Switch to Professional mode"
     },
     "questions": {
       "title": "Think Before You Explore",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1014,10 +1014,14 @@
       "foundation": "基础层",
       "application": "应用层",
       "research": "研究层",
+      "explore": "探索",
+      "professional": "专业",
       "foundationDesc": "PSRT问题驱动:用最简单的方式理解光的奥秘，不需要公式！",
       "applicationDesc": "ESRT轮转训练:动手实验，结合关键公式和概念深入理解",
       "researchDesc": "ORIC/SURF自主研究:严谨的学术表述，前沿研究视角",
-      "formulaHidden": "想看公式？切换到「应用层」或「研究层」模式"
+      "exploreDesc": "用直观的方式探索偏振光的奥秘，适合入门学习",
+      "professionalDesc": "深入专业知识，包含数学公式和研究级内容",
+      "formulaHidden": "想看公式？切换到「专业」模式"
     },
     "questions": {
       "title": "探索前的思考",
@@ -1061,10 +1065,14 @@
       "foundation": "基础层",
       "application": "应用层",
       "research": "研究层",
+      "explore": "探索",
+      "professional": "专业",
       "foundationDesc": "PSRT问题驱动:用最简单的方式理解光的奥秘，不需要公式！",
       "applicationDesc": "ESRT轮转训练:动手实验，结合关键公式和概念深入理解",
       "researchDesc": "ORIC/SURF自主研究:严谨的学术表述，前沿研究视角",
-      "formulaHidden": "想看公式？切换到「应用层」或「研究层」模式"
+      "exploreDesc": "用直观的方式探索偏振光的奥秘，适合入门学习",
+      "professionalDesc": "深入专业知识，包含数学公式和研究级内容",
+      "formulaHidden": "想看公式？切换到「专业」模式"
     },
     "questions": {
       "title": "探索前的思考",


### PR DESCRIPTION
…onal

The demo gallery was showing raw translation keys (gallery.difficulty.explore, gallery.difficulty.professional) instead of the actual translated text.

Added missing i18n translations:
- gallery.difficulty.explore / gallery.difficulty.professional
- gallery.difficulty.exploreDesc / gallery.difficulty.professionalDesc

Updated in both en.json and zh.json (gallery and course sections).