### PR TITLE
Fix polarization demo display and multilingual issues

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1008,7 +1008,8 @@
       "experiment": "Experimental Application",
       "frontier": "Frontier Application",
       "diy": "Try It Yourself",
-      "resources": "Further Reading"
+      "resources": "Further Reading",
+      "experience": "Experience Polarization"
     },
     "resourcesDisclaimer": "External resources for reference only.",
     "resourceTypes": {
@@ -1059,7 +1060,8 @@
       "experiment": "Experimental Application",
       "frontier": "Frontier Application",
       "diy": "Try It Yourself",
-      "resources": "Further Reading"
+      "resources": "Further Reading",
+      "experience": "Experience Polarization"
     },
     "resourcesDisclaimer": "External resources for reference only.",
     "resourceTypes": {
@@ -4171,6 +4173,10 @@
       "controlPanel": "Parameter Control",
       "calculationResult": "Calculation Result",
       "cameraFilter": "Camera Filter"
+    },
+    "aragoFresnel": {
+      "title": "Arago-Fresnel Laws",
+      "subtitle": "Interference of orthogonally polarized light and the role of the analyzer"
     },
     "polarizationState": {
       "parameters": "Parameter Adjustment",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1007,7 +1007,9 @@
       "physics": "物理原理",
       "experiment": "实验应用",
       "frontier": "前沿应用",
-      "diy": "动手试试"
+      "diy": "动手试试",
+      "resources": "延伸阅读",
+      "experience": "体验偏振"
     },
     "difficulty": {
       "label": "课程难度层级",
@@ -1051,7 +1053,8 @@
       "experiment": "实验应用",
       "frontier": "前沿应用",
       "diy": "动手试试",
-      "resources": "延伸阅读"
+      "resources": "延伸阅读",
+      "experience": "体验偏振"
     },
     "resourcesDisclaimer": "以下资源来自外部网站，仅供参考学习。",
     "resourceTypes": {
@@ -4136,6 +4139,10 @@
       "controlPanel": "参数控制",
       "calculationResult": "计算结果",
       "cameraFilter": "相机滤镜"
+    },
+    "aragoFresnel": {
+      "title": "阿拉戈-菲涅尔定律",
+      "subtitle": "正交偏振光的干涉与检偏器的作用"
     },
     "polarizationState": {
       "parameters": "参数调节",


### PR DESCRIPTION
- Add 'gallery.cards.experience' key to both locales (fixes raw key display)
- Add 'demoUi.aragoFresnel.title' and 'subtitle' keys for Arago-Fresnel demo
- Sync 'course.cards' section in zh.json to include 'resources' and 'experience'