### PR TITLE
fix: add dark/light theme support to all demo components

### DIFF
--- a/src/components/demos/Demo2DCanvas.tsx
+++ b/src/components/demos/Demo2DCanvas.tsx
@@ -3,6 +3,7 @@
  * 用于菲涅尔方程、斯托克斯矢量等2D可视化
  */
 import { useRef, useEffect, useCallback } from 'react'
+import { useTheme } from '@/contexts/ThemeContext'
 
 interface Demo2DCanvasProps {
   width?: number
@@ -18,6 +19,7 @@ export function Demo2DCanvas({
   className = '',
 }: Demo2DCanvasProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
+  const { theme } = useTheme()
 
   const render = useCallback(() => {
     const canvas = canvasRef.current
@@ -48,7 +50,7 @@ export function Demo2DCanvas({
   return (
     <canvas
       ref={canvasRef}
-      className={`bg-slate-900/50 rounded-lg ${className}`}
+      className={`rounded-lg ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100/50'} ${className}`}
       style={{ width, height }}
     />
   )

--- a/src/components/demos/DemoErrorBoundary.tsx
+++ b/src/components/demos/DemoErrorBoundary.tsx
@@ -43,12 +43,12 @@ export class DemoErrorBoundary extends Component<Props, State> {
       }
 
       return (
-        <div className="flex flex-col items-center justify-center p-8 bg-slate-800/50 rounded-lg border border-red-500/30">
-          <AlertTriangle className="w-12 h-12 text-red-400 mb-4" />
-          <h3 className="text-lg font-medium text-red-400 mb-2">
+        <div className="flex flex-col items-center justify-center p-8 bg-red-50 dark:bg-slate-800/50 rounded-lg border border-red-200 dark:border-red-500/30">
+          <AlertTriangle className="w-12 h-12 text-red-500 dark:text-red-400 mb-4" />
+          <h3 className="text-lg font-medium text-red-600 dark:text-red-400 mb-2">
             {this.props.demoName ? `"${this.props.demoName}" failed to load` : 'Demo failed to load'}
           </h3>
-          <p className="text-sm text-slate-400 mb-4 text-center max-w-md">
+          <p className="text-sm text-gray-600 dark:text-slate-400 mb-4 text-center max-w-md">
             {this.state.error?.message || 'An unexpected error occurred while rendering this demo.'}
           </p>
           <button

--- a/src/components/demos/basics/ElectromagneticSpectrumDemo.tsx
+++ b/src/components/demos/basics/ElectromagneticSpectrumDemo.tsx
@@ -6,6 +6,7 @@
 import { useState, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/contexts/ThemeContext'
 import { ControlPanel, Toggle, InfoCard } from '../DemoControls'
 
 // 电磁波谱区域定义
@@ -190,6 +191,7 @@ function formatWavelength(meters: number): string {
 
 export function ElectromagneticSpectrumDemo() {
   const { i18n } = useTranslation()
+  const { theme } = useTheme()
   const isZh = i18n.language === 'zh'
 
   const [selectedRegion, setSelectedRegion] = useState<string | null>('visible')
@@ -208,7 +210,7 @@ export function ElectromagneticSpectrumDemo() {
       <div className="flex gap-6 flex-col lg:flex-row">
         {/* 主可视化区域 */}
         <div className="flex-1">
-          <div className="bg-gradient-to-br from-slate-900 via-slate-900 to-indigo-950 rounded-xl border border-indigo-500/20 p-4 overflow-hidden">
+          <div className={`${theme === 'dark' ? 'bg-gradient-to-br from-slate-900 via-slate-900 to-indigo-950 border-indigo-500/20' : 'bg-gradient-to-br from-white via-gray-50 to-indigo-50 border-indigo-200'} rounded-xl border p-4 overflow-hidden`}>
             <svg viewBox="0 0 800 400" className="w-full h-auto" style={{ minHeight: '360px' }}>
               <defs>
                 {/* 背景网格 */}
@@ -545,8 +547,8 @@ export function ElectromagneticSpectrumDemo() {
             onChange={setShowVisibleExpanded}
           />
 
-          <div className="border-t border-slate-700 pt-4 mt-4">
-            <h4 className="text-sm font-medium text-gray-300 mb-2">
+          <div className={`border-t ${theme === 'dark' ? 'border-slate-700' : 'border-gray-200'} pt-4 mt-4`}>
+            <h4 className={`text-sm font-medium ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'} mb-2`}>
               {isZh ? '选择波段' : 'Select Region'}
             </h4>
             <div className="grid grid-cols-2 gap-2">
@@ -576,7 +578,7 @@ export function ElectromagneticSpectrumDemo() {
       {/* 知识卡片 */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <InfoCard title={isZh ? '光的本质' : 'Nature of Light'} color="cyan">
-          <ul className="text-xs text-gray-300 space-y-1.5">
+          <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-1.5`}>
             <li>
               • {isZh ? '光是电磁波，不需要介质传播' : 'Light is EM wave, no medium needed'}
             </li>
@@ -590,7 +592,7 @@ export function ElectromagneticSpectrumDemo() {
         </InfoCard>
 
         <InfoCard title={isZh ? '能量与波长' : 'Energy & Wavelength'} color="purple">
-          <ul className="text-xs text-gray-300 space-y-1.5">
+          <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-1.5`}>
             <li>
               • {isZh ? '光子能量：E = hf = hc/λ' : 'Photon energy: E = hf = hc/λ'}
             </li>
@@ -604,7 +606,7 @@ export function ElectromagneticSpectrumDemo() {
         </InfoCard>
 
         <InfoCard title={isZh ? '人眼视觉' : 'Human Vision'} color="green">
-          <ul className="text-xs text-gray-300 space-y-1.5">
+          <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-1.5`}>
             <li>
               • {isZh ? '人眼仅能看见380-700nm范围' : 'Human eyes see only 380-700nm'}
             </li>

--- a/src/components/demos/basics/ElectromagneticWaveDemo.tsx
+++ b/src/components/demos/basics/ElectromagneticWaveDemo.tsx
@@ -12,6 +12,7 @@
 import { useState, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/contexts/ThemeContext'
 import { Waves, BarChart3 } from 'lucide-react'
 import { SliderControl, ControlPanel, ValueDisplay, Toggle, InfoCard, Formula } from '../DemoControls'
 import { DifficultyLevel, useDifficultyConfig, WhyButton, DifficultyGate } from '../DifficultyStrategy'
@@ -197,6 +198,7 @@ interface Props {
 
 export function ElectromagneticWaveDemo({ difficultyLevel = 'explore' }: Props) {
   const { t, i18n } = useTranslation()
+  const { theme } = useTheme()
   const isZh = i18n.language === 'zh'
   const config = useDifficultyConfig(difficultyLevel)
 
@@ -289,13 +291,13 @@ export function ElectromagneticWaveDemo({ difficultyLevel = 'explore' }: Props) 
   return (
     <div className="space-y-6">
       {/* View Mode Tabs */}
-      <div className="flex gap-2 p-1 bg-slate-800/50 rounded-lg w-fit">
+      <div className={`flex gap-2 p-1 ${theme === 'dark' ? 'bg-slate-800/50' : 'bg-gray-100'} rounded-lg w-fit`}>
         <button
           onClick={() => setViewMode('wave')}
           className={`flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-all ${
             viewMode === 'wave'
               ? 'bg-cyan-500/20 text-cyan-400 shadow-sm'
-              : 'text-gray-400 hover:text-gray-300 hover:bg-slate-700/50'
+              : `${theme === 'dark' ? 'text-gray-400 hover:text-gray-300 hover:bg-slate-700/50' : 'text-gray-500 hover:text-gray-700 hover:bg-gray-200'}`
           }`}
         >
           <Waves className="w-4 h-4" />
@@ -306,7 +308,7 @@ export function ElectromagneticWaveDemo({ difficultyLevel = 'explore' }: Props) 
           className={`flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-all ${
             viewMode === 'spectrum'
               ? 'bg-purple-500/20 text-purple-400 shadow-sm'
-              : 'text-gray-400 hover:text-gray-300 hover:bg-slate-700/50'
+              : `${theme === 'dark' ? 'text-gray-400 hover:text-gray-300 hover:bg-slate-700/50' : 'text-gray-500 hover:text-gray-700 hover:bg-gray-200'}`
           }`}
         >
           <BarChart3 className="w-4 h-4" />
@@ -326,7 +328,7 @@ export function ElectromagneticWaveDemo({ difficultyLevel = 'explore' }: Props) 
             {/* Wave View Content */}
             <div className="flex gap-6 flex-col lg:flex-row">
               <div className="flex-1">
-                <div className="bg-gradient-to-br from-slate-900 via-slate-900 to-blue-950 rounded-xl border border-blue-500/20 p-4 overflow-hidden">
+                <div className={`${theme === 'dark' ? 'bg-gradient-to-br from-slate-900 via-slate-900 to-blue-950 border-blue-500/20' : 'bg-gradient-to-br from-white via-gray-50 to-blue-50 border-blue-200'} rounded-xl border p-4 overflow-hidden`}>
                   <svg
                     viewBox="0 0 700 300"
                     className="w-full h-auto"
@@ -410,8 +412,8 @@ export function ElectromagneticWaveDemo({ difficultyLevel = 'explore' }: Props) 
                 </div>
 
                 {/* Visible Spectrum Bar */}
-                <div className="mt-4 p-4 rounded-lg bg-slate-800/50 border border-slate-700/50">
-                  <h4 className="text-sm font-semibold text-gray-300 mb-2">{t('demoUi.common.visibleSpectrum')}</h4>
+                <div className={`mt-4 p-4 rounded-lg ${theme === 'dark' ? 'bg-slate-800/50 border-slate-700/50' : 'bg-gray-50 border-gray-200'} border`}>
+                  <h4 className={`text-sm font-semibold ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'} mb-2`}>{t('demoUi.common.visibleSpectrum')}</h4>
                   <div
                     className="h-8 rounded cursor-pointer relative"
                     style={{
@@ -431,7 +433,7 @@ export function ElectromagneticWaveDemo({ difficultyLevel = 'explore' }: Props) 
                       layoutId="wavelength-indicator"
                     />
                   </div>
-                  <div className="flex justify-between text-xs text-gray-400 mt-1">
+                  <div className={`flex justify-between text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'} mt-1`}>
                     <span>380 nm ({t('demoUi.common.violet')})</span>
                     <span>550 nm ({t('demoUi.common.green')})</span>
                     <span>700 nm ({t('demoUi.common.red')})</span>
@@ -488,7 +490,7 @@ export function ElectromagneticWaveDemo({ difficultyLevel = 'explore' }: Props) 
                   {isPlaying ? t('demoUi.common.pause') : t('demoUi.common.play')}
                 </motion.button>
 
-                <div className="pt-2 border-t border-slate-700">
+                <div className={`pt-2 border-t ${theme === 'dark' ? 'border-slate-700' : 'border-gray-200'}`}>
                   <ValueDisplay label={t('demoUi.common.color')} value={waveColor} />
                   {/* 使用精确光速值 c = 2.998×10^8 m/s 计算频率 f = c/λ */}
                   <ValueDisplay label={t('demoUi.common.frequency')} value={`${(2.998e8 / (wavelength * 1e-9) / 1e14).toFixed(2)} × 10¹⁴ Hz`} />
@@ -519,7 +521,7 @@ export function ElectromagneticWaveDemo({ difficultyLevel = 'explore' }: Props) 
             <DifficultyGate level="explore" currentLevel={difficultyLevel} showWhen="at-least">
               <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
                 <InfoCard title={isZh ? '电磁波特性' : 'EM Wave Properties'} color="cyan">
-                  <ul className="text-xs text-gray-300 space-y-1.5">
+                  <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-1.5`}>
                     <li>• {isZh ? 'E场和B场相互垂直' : 'E and B fields are perpendicular'}</li>
                     <li>• {isZh ? '横波：振动方向垂直于传播方向' : 'Transverse: oscillation ⊥ propagation'}</li>
                     <li>• {isZh ? '真空中速度恒定：c = 3×10⁸ m/s' : 'Constant speed in vacuum: c = 3×10⁸ m/s'}</li>
@@ -529,7 +531,7 @@ export function ElectromagneticWaveDemo({ difficultyLevel = 'explore' }: Props) 
                   )}
                 </InfoCard>
                 <InfoCard title={isZh ? '与偏振的联系' : 'Connection to Polarization'} color="purple">
-                  <ul className="text-xs text-gray-300 space-y-1.5">
+                  <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-1.5`}>
                     <li>• {isZh ? '偏振描述电场振动方向' : 'Polarization describes E-field oscillation direction'}</li>
                     <li>• {isZh ? '自然光包含所有偏振方向' : 'Natural light contains all polarization directions'}</li>
                     <li>• {isZh ? '只有横波才能偏振' : 'Only transverse waves can be polarized'}</li>
@@ -549,7 +551,7 @@ export function ElectromagneticWaveDemo({ difficultyLevel = 'explore' }: Props) 
             {/* Spectrum View Content */}
             <div className="flex gap-6 flex-col lg:flex-row">
               <div className="flex-1">
-                <div className="bg-gradient-to-br from-slate-900 via-slate-900 to-indigo-950 rounded-xl border border-indigo-500/20 p-4 overflow-hidden">
+                <div className={`${theme === 'dark' ? 'bg-gradient-to-br from-slate-900 via-slate-900 to-indigo-950 border-indigo-500/20' : 'bg-gradient-to-br from-white via-gray-50 to-indigo-50 border-indigo-200'} rounded-xl border p-4 overflow-hidden`}>
                   <svg viewBox="0 0 800 380" className="w-full h-auto" style={{ minHeight: '360px' }}>
                     <defs>
                       <pattern id="spectrum-grid" width="40" height="40" patternUnits="userSpaceOnUse">
@@ -753,8 +755,8 @@ export function ElectromagneticWaveDemo({ difficultyLevel = 'explore' }: Props) 
                   onChange={setShowSizeComparison}
                 />
 
-                <div className="border-t border-slate-700 pt-4 mt-4">
-                  <h4 className="text-sm font-medium text-gray-300 mb-2">
+                <div className={`border-t ${theme === 'dark' ? 'border-slate-700' : 'border-gray-200'} pt-4 mt-4`}>
+                  <h4 className={`text-sm font-medium ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'} mb-2`}>
                     {isZh ? '选择波段' : 'Select Region'}
                   </h4>
                   <div className="grid grid-cols-2 gap-2">
@@ -804,7 +806,7 @@ export function ElectromagneticWaveDemo({ difficultyLevel = 'explore' }: Props) 
             <DifficultyGate level="explore" currentLevel={difficultyLevel} showWhen="at-least">
               <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
                 <InfoCard title={isZh ? '光的本质' : 'Nature of Light'} color="cyan">
-                  <ul className="text-xs text-gray-300 space-y-1.5">
+                  <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-1.5`}>
                     <li>• {isZh ? '光是电磁波，不需要介质' : 'Light is EM wave, no medium needed'}</li>
                     <li>• {isZh ? '波长与频率成反比' : 'λ inversely proportional to f'}</li>
                     {config.showFormula && <li className="font-mono text-cyan-400">c = λf = 3×10⁸ m/s</li>}
@@ -812,7 +814,7 @@ export function ElectromagneticWaveDemo({ difficultyLevel = 'explore' }: Props) 
                 </InfoCard>
 
                 <InfoCard title={isZh ? '能量与波长' : 'Energy & Wavelength'} color="purple">
-                  <ul className="text-xs text-gray-300 space-y-1.5">
+                  <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-1.5`}>
                     <li>• {isZh ? '波长越短，能量越高' : 'Shorter λ = higher energy'}</li>
                     <li>• {isZh ? '伽马射线能量最高' : 'Gamma rays have highest energy'}</li>
                     {config.showFormula && <li className="font-mono text-purple-400">E = hf = hc/λ</li>}
@@ -820,7 +822,7 @@ export function ElectromagneticWaveDemo({ difficultyLevel = 'explore' }: Props) 
                 </InfoCard>
 
                 <InfoCard title={isZh ? '人眼视觉' : 'Human Vision'} color="green">
-                  <ul className="text-xs text-gray-300 space-y-1.5">
+                  <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-1.5`}>
                     <li>• {isZh ? '人眼仅见380-700nm' : 'Eyes see only 380-700nm'}</li>
                     <li>• {isZh ? '对绿光最敏感(~555nm)' : 'Most sensitive to green (~555nm)'}</li>
                     <li>• {isZh ? '可见光只占极小部分' : 'Visible is tiny fraction of spectrum'}</li>

--- a/src/components/demos/basics/InteractiveOpticalBenchDemo.tsx
+++ b/src/components/demos/basics/InteractiveOpticalBenchDemo.tsx
@@ -6,6 +6,7 @@
 
 import { useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/contexts/ThemeContext'
 import { ControlPanel, SliderControl, Toggle, InfoCard, PresetButtons, Formula } from '../DemoControls'
 
 // 导入共享模块
@@ -32,6 +33,7 @@ const PRESETS = [
 
 export function InteractiveOpticalBenchDemo() {
   const { i18n } = useTranslation()
+  const { theme } = useTheme()
   const isZh = i18n.language === 'zh'
 
   // 交互状态
@@ -97,7 +99,7 @@ export function InteractiveOpticalBenchDemo() {
     <div className="flex flex-col lg:flex-row gap-6 w-full">
       {/* 可视化区域 */}
       <div className="flex-1 min-w-0">
-        <div className="bg-slate-900/50 rounded-xl p-4 border border-slate-700/50">
+        <div className={`${theme === 'dark' ? 'bg-slate-900/50 border-slate-700/50' : 'bg-white border-gray-200'} rounded-xl p-4 border`}>
           <svg viewBox="0 0 100 70" className="w-full h-auto max-h-[280px]" style={{ background: '#0a0a1a' }}>
             <defs>
               <LightBeamDefs />
@@ -193,16 +195,16 @@ export function InteractiveOpticalBenchDemo() {
 
         {/* 物理量显示 */}
         <div className="mt-4 grid grid-cols-3 gap-3">
-          <div className="bg-slate-800/50 rounded-lg p-3 text-center">
-            <div className="text-xs text-slate-400 mb-1">{isZh ? '角度差' : 'Angle Diff'}</div>
+          <div className={`${theme === 'dark' ? 'bg-slate-800/50' : 'bg-gray-50'} rounded-lg p-3 text-center`}>
+            <div className={`text-xs ${theme === 'dark' ? 'text-slate-400' : 'text-gray-600'} mb-1`}>{isZh ? '角度差' : 'Angle Diff'}</div>
             <div className="text-xl font-mono text-cyan-400">{angleDiff}°</div>
           </div>
-          <div className="bg-slate-800/50 rounded-lg p-3 text-center">
-            <div className="text-xs text-slate-400 mb-1">{isZh ? '透射率' : 'Transmission'}</div>
+          <div className={`${theme === 'dark' ? 'bg-slate-800/50' : 'bg-gray-50'} rounded-lg p-3 text-center`}>
+            <div className={`text-xs ${theme === 'dark' ? 'text-slate-400' : 'text-gray-600'} mb-1`}>{isZh ? '透射率' : 'Transmission'}</div>
             <div className="text-xl font-mono text-green-400">{(transmission * 100).toFixed(1)}%</div>
           </div>
-          <div className="bg-slate-800/50 rounded-lg p-3 text-center">
-            <div className="text-xs text-slate-400 mb-1">{isZh ? '输出光强' : 'Output I'}</div>
+          <div className={`${theme === 'dark' ? 'bg-slate-800/50' : 'bg-gray-50'} rounded-lg p-3 text-center`}>
+            <div className={`text-xs ${theme === 'dark' ? 'text-slate-400' : 'text-gray-600'} mb-1`}>{isZh ? '输出光强' : 'Output I'}</div>
             <div className="text-xl font-mono text-yellow-400">{outputIntensity.toFixed(1)}%</div>
           </div>
         </div>
@@ -213,7 +215,7 @@ export function InteractiveOpticalBenchDemo() {
             {POLARIZATION_DISPLAY_CONFIG.map(({ angle, label, color }) => (
               <div key={angle} className="flex items-center gap-1.5">
                 <span className="w-3 h-3 rounded" style={{ backgroundColor: color }} />
-                <span className="text-xs text-slate-400">{label}</span>
+                <span className={`text-xs ${theme === 'dark' ? 'text-slate-400' : 'text-gray-600'}`}>{label}</span>
               </div>
             ))}
           </div>
@@ -283,7 +285,7 @@ export function InteractiveOpticalBenchDemo() {
           </p>
         </InfoCard>
 
-        <div className="text-xs text-slate-500 text-center">
+        <div className={`text-xs ${theme === 'dark' ? 'text-slate-500' : 'text-gray-500'} text-center`}>
           {isZh
             ? '此Demo使用共享的光学组件库构建'
             : 'Built with shared optical component library'}

--- a/src/components/demos/basics/LightWaveDemo.tsx
+++ b/src/components/demos/basics/LightWaveDemo.tsx
@@ -5,10 +5,12 @@
 import { useState, useMemo } from 'react'
 import { motion } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/contexts/ThemeContext'
 import { SliderControl, ControlPanel, ValueDisplay, Toggle, InfoCard } from '../DemoControls'
 
 export function LightWaveDemo() {
   const { t } = useTranslation()
+  const { theme } = useTheme()
   const [wavelength, setWavelength] = useState(550) // nm
   const [amplitude, setAmplitude] = useState(50)
   const [speed, setSpeed] = useState(0.5)
@@ -84,7 +86,7 @@ export function LightWaveDemo() {
       <div className="flex gap-6 flex-col lg:flex-row">
         {/* 可视化区域 */}
         <div className="flex-1">
-          <div className="bg-gradient-to-br from-slate-900 via-slate-900 to-blue-950 rounded-xl border border-blue-500/20 p-4 overflow-hidden">
+          <div className={`${theme === 'dark' ? 'bg-gradient-to-br from-slate-900 via-slate-900 to-blue-950 border-blue-500/20' : 'bg-gradient-to-br from-white via-gray-50 to-blue-50 border-blue-200'} rounded-xl border p-4 overflow-hidden`}>
             <svg
               viewBox="0 0 700 300"
               className="w-full h-auto"
@@ -177,8 +179,8 @@ export function LightWaveDemo() {
           </div>
 
           {/* 可见光谱 */}
-          <div className="mt-4 p-4 rounded-lg bg-slate-800/50 border border-slate-700/50">
-            <h4 className="text-sm font-semibold text-gray-300 mb-2">{t('demoUi.common.visibleSpectrum')}</h4>
+          <div className={`mt-4 p-4 rounded-lg ${theme === 'dark' ? 'bg-slate-800/50 border-slate-700/50' : 'bg-gray-50 border-gray-200'} border`}>
+            <h4 className={`text-sm font-semibold ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'} mb-2`}>{t('demoUi.common.visibleSpectrum')}</h4>
             <div
               className="h-8 rounded cursor-pointer relative"
               style={{
@@ -199,7 +201,7 @@ export function LightWaveDemo() {
                 layoutId="wavelength-indicator"
               />
             </div>
-            <div className="flex justify-between text-xs text-gray-400 mt-1">
+            <div className={`flex justify-between text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'} mt-1`}>
               <span>380 nm ({t('demoUi.common.violet')})</span>
               <span>550 nm ({t('demoUi.common.green')})</span>
               <span>700 nm ({t('demoUi.common.red')})</span>
@@ -259,7 +261,7 @@ export function LightWaveDemo() {
             {isPlaying ? t('demoUi.common.pause') : t('demoUi.common.play')}
           </motion.button>
 
-          <div className="pt-2 border-t border-slate-700">
+          <div className={`pt-2 border-t ${theme === 'dark' ? 'border-slate-700' : 'border-gray-200'}`}>
             <ValueDisplay label={t('demoUi.common.color')} value={waveColor} />
             <ValueDisplay label={t('demoUi.common.frequency')} value={`${(3e8 / (wavelength * 1e-9) / 1e14).toFixed(2)} × 10¹⁴ Hz`} />
           </div>
@@ -269,14 +271,14 @@ export function LightWaveDemo() {
       {/* 知识卡片 */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <InfoCard title={t('demoUi.lightWave.emWaveFeatures')} color="cyan">
-          <ul className="text-xs text-gray-300 space-y-1.5">
+          <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-1.5`}>
             {(t('demoUi.lightWave.emWaveDetails', { returnObjects: true }) as string[]).map((item, i) => (
               <li key={i}>• {item}</li>
             ))}
           </ul>
         </InfoCard>
         <InfoCard title={t('demoUi.lightWave.transverseFeatures')} color="purple">
-          <ul className="text-xs text-gray-300 space-y-1.5">
+          <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-1.5`}>
             {(t('demoUi.lightWave.transverseDetails', { returnObjects: true }) as string[]).map((item, i) => (
               <li key={i}>• {item}</li>
             ))}

--- a/src/components/demos/basics/MalusLawGraphDemo.tsx
+++ b/src/components/demos/basics/MalusLawGraphDemo.tsx
@@ -6,6 +6,7 @@
 import { useState, useMemo, useCallback } from 'react'
 import { motion } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/contexts/ThemeContext'
 import {
   ControlPanel,
   SliderControl,
@@ -59,6 +60,7 @@ const ANGLE_PRESETS = [
 
 export function MalusLawGraphDemo() {
   const { i18n } = useTranslation()
+  const { theme } = useTheme()
   const isZh = i18n.language === 'zh'
 
   // 状态
@@ -121,7 +123,7 @@ export function MalusLawGraphDemo() {
       <div className="flex gap-6 flex-col lg:flex-row">
         {/* 主可视化区域 */}
         <div className="flex-1">
-          <div className="bg-gradient-to-br from-slate-900 via-slate-900 to-blue-950 rounded-xl border border-blue-500/20 p-4 overflow-hidden">
+          <div className={`${theme === 'dark' ? 'bg-gradient-to-br from-slate-900 via-slate-900 to-blue-950 border-blue-500/20' : 'bg-gradient-to-br from-white via-gray-50 to-blue-50 border-blue-200'} rounded-xl border p-4 overflow-hidden`}>
             <svg viewBox="0 0 600 420" className="w-full h-auto" style={{ minHeight: '400px' }}>
               <defs>
                 <pattern id="malus-grid" width="40" height="40" patternUnits="userSpaceOnUse">
@@ -435,10 +437,10 @@ export function MalusLawGraphDemo() {
 
           {/* 强度条 */}
           {showIntensityBar && (
-            <div className="mt-4 p-4 bg-slate-800/50 rounded-lg border border-slate-700/50">
+            <div className={`mt-4 p-4 ${theme === 'dark' ? 'bg-slate-800/50 border-slate-700/50' : 'bg-gray-50 border-gray-200'} rounded-lg border`}>
               <div className="flex items-center gap-4">
-                <span className="text-sm text-gray-400 w-20">{isZh ? '输出光强' : 'Output I'}</span>
-                <div className="flex-1 h-6 bg-slate-700 rounded-full overflow-hidden">
+                <span className={`text-sm ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'} w-20`}>{isZh ? '输出光强' : 'Output I'}</span>
+                <div className={`flex-1 h-6 ${theme === 'dark' ? 'bg-slate-700' : 'bg-gray-200'} rounded-full overflow-hidden`}>
                   <motion.div
                     className="h-full rounded-full"
                     style={{
@@ -551,7 +553,7 @@ export function MalusLawGraphDemo() {
       {/* 知识卡片 */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <InfoCard title={isZh ? '关键特点' : 'Key Features'} color="cyan">
-          <ul className="text-xs text-gray-300 space-y-1.5">
+          <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-1.5`}>
             <li>• {isZh ? '曲线关于θ=90°对称' : 'Curve symmetric about θ=90°'}</li>
             <li>• {isZh ? '最大值在θ=0°和180°' : 'Maximum at θ=0° and 180°'}</li>
             <li>• {isZh ? '最小值在θ=90°（完全消光）' : 'Minimum at θ=90° (extinction)'}</li>
@@ -560,7 +562,7 @@ export function MalusLawGraphDemo() {
         </InfoCard>
 
         <InfoCard title={isZh ? '物理意义' : 'Physical Meaning'} color="purple">
-          <ul className="text-xs text-gray-300 space-y-1.5">
+          <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-1.5`}>
             <li>• {isZh ? 'cos(θ)代表电场分量的投影' : 'cos(θ) = E-field component projection'}</li>
             <li>• {isZh ? '光强与电场幅度的平方成正比' : 'Intensity ∝ E-field amplitude²'}</li>
             <li>• {isZh ? '因此光强与cos²(θ)成正比' : 'Therefore intensity ∝ cos²(θ)'}</li>
@@ -568,7 +570,7 @@ export function MalusLawGraphDemo() {
         </InfoCard>
 
         <InfoCard title={isZh ? '实际应用' : 'Applications'} color="green">
-          <ul className="text-xs text-gray-300 space-y-1.5">
+          <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-1.5`}>
             <li>• {isZh ? '偏振眼镜减少眩光' : 'Polarized sunglasses reduce glare'}</li>
             <li>• {isZh ? 'LCD显示器亮度控制' : 'LCD brightness control'}</li>
             <li>• {isZh ? '光学仪器中的光强调节' : 'Light intensity modulation in optics'}</li>

--- a/src/components/demos/basics/PolarizationIntroDemo.tsx
+++ b/src/components/demos/basics/PolarizationIntroDemo.tsx
@@ -5,6 +5,7 @@
 import { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/contexts/ThemeContext'
 import { SliderControl, ControlPanel, InfoCard } from '../DemoControls'
 
 // 电场矢量组件
@@ -83,6 +84,7 @@ function PolarizedPanel({
   polarizationAngle,
   animationSpeed,
   propagationText,
+  theme,
 }: {
   title: string
   subtitle: string
@@ -90,23 +92,32 @@ function PolarizedPanel({
   polarizationAngle: number
   animationSpeed: number
   propagationText: string
+  theme: 'dark' | 'light'
 }) {
   // 非偏振光的随机角度
   const randomAngles = [0, 25, 50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 350]
 
   return (
-    <div className="flex-1 rounded-xl bg-gradient-to-br from-slate-900 via-slate-900/95 to-slate-800 border border-slate-700/50 p-4">
+    <div className={`flex-1 rounded-xl bg-gradient-to-br p-4 border ${
+      theme === 'dark'
+        ? 'from-slate-900 via-slate-900/95 to-slate-800 border-slate-700/50'
+        : 'from-white via-gray-50 to-amber-50/50 border-gray-200'
+    }`}>
       <div className="text-center mb-4">
-        <h3 className={`text-lg font-semibold ${isUnpolarized ? 'text-yellow-400' : 'text-cyan-400'}`}>
+        <h3 className={`text-lg font-semibold ${isUnpolarized ? 'text-yellow-500' : 'text-cyan-500'} ${theme === 'dark' ? '' : ''}`}>
           {title}
         </h3>
-        <p className="text-xs text-gray-400 mt-1">{subtitle}</p>
+        <p className={`text-xs mt-1 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>{subtitle}</p>
       </div>
 
       {/* 电场矢量可视化 */}
       <div className="relative w-full aspect-square max-w-[200px] mx-auto mb-4">
         {/* 背景圆 */}
-        <div className="absolute inset-0 rounded-full border border-slate-600/50 bg-slate-900/50" />
+        <div className={`absolute inset-0 rounded-full border ${
+          theme === 'dark'
+            ? 'border-slate-600/50 bg-slate-900/50'
+            : 'border-gray-300 bg-white'
+        }`} />
 
         {/* 中心光源点 */}
         <motion.div
@@ -156,7 +167,7 @@ function PolarizedPanel({
       </div>
 
       {/* 传播方向指示 */}
-      <div className="flex items-center justify-center gap-2 text-gray-500 text-sm">
+      <div className={`flex items-center justify-center gap-2 text-sm ${theme === 'dark' ? 'text-gray-500' : 'text-gray-600'}`}>
         <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
           <circle cx="12" cy="12" r="3" fill="currentColor" />
           <circle cx="12" cy="12" r="8" />
@@ -167,7 +178,7 @@ function PolarizedPanel({
       {/* 偏振角显示 */}
       {!isUnpolarized && (
         <motion.div
-          className="mt-3 text-center text-cyan-400 font-mono text-sm"
+          className="mt-3 text-center text-cyan-500 font-mono text-sm"
           key={polarizationAngle}
           initial={{ opacity: 0, y: -10 }}
           animate={{ opacity: 1, y: 0 }}
@@ -181,6 +192,7 @@ function PolarizedPanel({
 
 export function PolarizationIntroDemo() {
   const { t } = useTranslation()
+  const { theme } = useTheme()
   const [polarizationAngle, setPolarizationAngle] = useState(0)
   const [animationSpeed, setAnimationSpeed] = useState(0.5)
   const [showComparison, setShowComparison] = useState(true)
@@ -205,6 +217,7 @@ export function PolarizationIntroDemo() {
                   polarizationAngle={0}
                   animationSpeed={animationSpeed}
                   propagationText={t('demoUi.polarizationIntro.propagationDirection')}
+                  theme={theme}
                 />
               </motion.div>
             )}
@@ -217,6 +230,7 @@ export function PolarizationIntroDemo() {
             polarizationAngle={polarizationAngle}
             animationSpeed={animationSpeed}
             propagationText={t('demoUi.polarizationIntro.propagationDirection')}
+            theme={theme}
           />
         </div>
 
@@ -244,15 +258,17 @@ export function PolarizationIntroDemo() {
 
           {/* 预设角度按钮 */}
           <div className="space-y-2">
-            <span className="text-xs text-gray-400">{t('demoUi.common.quickSelect')}</span>
+            <span className={`text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>{t('demoUi.common.quickSelect')}</span>
             <div className="grid grid-cols-4 gap-1">
               {[0, 45, 90, 135].map((angle) => (
                 <motion.button
                   key={angle}
                   className={`py-1.5 rounded text-xs font-medium transition-all ${
                     polarizationAngle === angle
-                      ? 'bg-cyan-400/30 text-cyan-400 border border-cyan-400/50'
-                      : 'bg-slate-700/50 text-gray-400 border border-slate-600/50 hover:border-cyan-400/30'
+                      ? 'bg-cyan-400/30 text-cyan-500 border border-cyan-400/50'
+                      : theme === 'dark'
+                        ? 'bg-slate-700/50 text-gray-400 border border-slate-600/50 hover:border-cyan-400/30'
+                        : 'bg-gray-100 text-gray-600 border border-gray-300 hover:border-cyan-400/50'
                   }`}
                   whileHover={{ scale: 1.05 }}
                   whileTap={{ scale: 0.95 }}
@@ -269,22 +285,22 @@ export function PolarizationIntroDemo() {
               type="checkbox"
               checked={showComparison}
               onChange={(e) => setShowComparison(e.target.checked)}
-              className="rounded border-gray-600 bg-slate-700 text-cyan-400"
+              className={`rounded text-cyan-500 ${theme === 'dark' ? 'border-gray-600 bg-slate-700' : 'border-gray-300 bg-white'}`}
             />
-            <span className="text-sm text-gray-300">{t('demoUi.common.showComparison')}</span>
+            <span className={`text-sm ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}`}>{t('demoUi.common.showComparison')}</span>
           </label>
 
           {/* 关键概念 */}
-          <div className="mt-4 pt-4 border-t border-slate-700 space-y-2">
-            <h4 className="text-sm font-semibold text-gray-300">{t('demoUi.common.keyConcepts')}</h4>
-            <div className="text-xs text-gray-400 space-y-1.5">
+          <div className={`mt-4 pt-4 border-t space-y-2 ${theme === 'dark' ? 'border-slate-700' : 'border-gray-200'}`}>
+            <h4 className={`text-sm font-semibold ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}`}>{t('demoUi.common.keyConcepts')}</h4>
+            <div className={`text-xs space-y-1.5 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
               <p className="flex items-start gap-2">
                 <span className="w-2 h-2 rounded-full bg-yellow-400 mt-1 flex-shrink-0" />
-                <span><strong className="text-yellow-400">{t('demoUi.polarizationIntro.unpolarizedLight')}:</strong> {t('demoUi.polarizationIntro.unpolarizedDesc')}</span>
+                <span><strong className="text-yellow-500">{t('demoUi.polarizationIntro.unpolarizedLight')}:</strong> {t('demoUi.polarizationIntro.unpolarizedDesc')}</span>
               </p>
               <p className="flex items-start gap-2">
                 <span className="w-2 h-2 rounded-full bg-cyan-400 mt-1 flex-shrink-0" />
-                <span><strong className="text-cyan-400">{t('demoUi.polarizationIntro.polarizedLight')}:</strong> {t('demoUi.polarizationIntro.polarizedDesc')}</span>
+                <span><strong className="text-cyan-500">{t('demoUi.polarizationIntro.polarizedLight')}:</strong> {t('demoUi.polarizationIntro.polarizedDesc')}</span>
               </p>
             </div>
           </div>
@@ -294,14 +310,14 @@ export function PolarizationIntroDemo() {
       {/* 信息卡片 */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <InfoCard title={t('demoUi.polarizationIntro.unpolarizedLight')} color="orange">
-          <ul className="text-xs text-gray-300 space-y-1.5">
+          <ul className={`text-xs space-y-1.5 ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
             {(t('demoUi.polarizationIntro.unpolarizedDetails', { returnObjects: true }) as string[]).map((item, i) => (
               <li key={i}>• {item}</li>
             ))}
           </ul>
         </InfoCard>
         <InfoCard title={t('demoUi.polarizationIntro.polarizedLight')} color="cyan">
-          <ul className="text-xs text-gray-300 space-y-1.5">
+          <ul className={`text-xs space-y-1.5 ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
             {(t('demoUi.polarizationIntro.polarizedDetails', { returnObjects: true }) as string[]).map((item, i) => (
               <li key={i}>• {item}</li>
             ))}
@@ -310,8 +326,8 @@ export function PolarizationIntroDemo() {
       </div>
 
       {/* 偏振方向颜色编码 */}
-      <div className="p-4 rounded-lg bg-slate-800/50 border border-slate-700/50">
-        <h4 className="text-sm font-semibold text-gray-300 mb-3">{t('demoUi.polarizationIntro.colorCode')}</h4>
+      <div className={`p-4 rounded-lg border ${theme === 'dark' ? 'bg-slate-800/50 border-slate-700/50' : 'bg-gray-50 border-gray-200'}`}>
+        <h4 className={`text-sm font-semibold mb-3 ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}`}>{t('demoUi.polarizationIntro.colorCode')}</h4>
         <div className="flex gap-4 justify-center flex-wrap">
           {[
             { angle: 0, color: '#ef4444', labelKey: 'demoUi.polarizationIntro.horizontal' },
@@ -323,8 +339,12 @@ export function PolarizationIntroDemo() {
               key={angle}
               className={`flex items-center gap-2 px-3 py-2 rounded-lg border transition-all ${
                 polarizationAngle === angle
-                  ? 'border-white/50 bg-slate-700/50'
-                  : 'border-slate-600/50 hover:border-slate-500/50'
+                  ? theme === 'dark'
+                    ? 'border-white/50 bg-slate-700/50'
+                    : 'border-gray-400 bg-gray-100'
+                  : theme === 'dark'
+                    ? 'border-slate-600/50 hover:border-slate-500/50'
+                    : 'border-gray-200 hover:border-gray-300'
               }`}
               whileHover={{ scale: 1.02 }}
               whileTap={{ scale: 0.98 }}
@@ -334,7 +354,7 @@ export function PolarizationIntroDemo() {
                 className="w-4 h-4 rounded-full"
                 style={{ backgroundColor: color, boxShadow: `0 0 8px ${color}` }}
               />
-              <span className="text-sm text-gray-300">{t(labelKey)}</span>
+              <span className={`text-sm ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}`}>{t(labelKey)}</span>
             </motion.button>
           ))}
         </div>

--- a/src/components/demos/basics/PolarizationTypesDemo.tsx
+++ b/src/components/demos/basics/PolarizationTypesDemo.tsx
@@ -5,12 +5,14 @@
 import { useState, useMemo, useEffect } from 'react'
 import { motion } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/contexts/ThemeContext'
 import { SliderControl, ControlPanel, InfoCard } from '../DemoControls'
 
 type PolarizationType = 'linear' | 'circular' | 'elliptical'
 
 export function PolarizationTypesDemo() {
   const { t } = useTranslation()
+  const { theme } = useTheme()
   const [polarizationType, setPolarizationType] = useState<PolarizationType>('linear')
   const [linearAngle, setLinearAngle] = useState(45)
   const [ellipseRatio, setEllipseRatio] = useState(0.5)
@@ -112,7 +114,7 @@ export function PolarizationTypesDemo() {
       <div className="flex gap-6 flex-col lg:flex-row">
         {/* SVG 可视化区域 */}
         <div className="flex-1">
-          <div className="bg-gradient-to-br from-slate-900 via-slate-900 to-indigo-950 rounded-xl border border-indigo-500/20 p-4">
+          <div className={`${theme === 'dark' ? 'bg-gradient-to-br from-slate-900 via-slate-900 to-indigo-950 border-indigo-500/20' : 'bg-gradient-to-br from-white via-gray-50 to-indigo-50 border-indigo-200'} rounded-xl border p-4`}>
             <svg viewBox="0 0 400 400" className="w-full h-auto max-w-[400px] mx-auto">
               <defs>
                 {/* 发光滤镜 */}
@@ -206,8 +208,8 @@ export function PolarizationTypesDemo() {
           </div>
 
           {/* 类型选择器 */}
-          <div className="mt-4 p-4 rounded-lg bg-slate-800/50 border border-slate-700/50">
-            <h4 className="text-sm font-semibold text-gray-300 mb-3">{t('demoUi.common.polarizationType')}</h4>
+          <div className={`mt-4 p-4 rounded-lg ${theme === 'dark' ? 'bg-slate-800/50 border-slate-700/50' : 'bg-gray-50 border-gray-200'} border`}>
+            <h4 className={`text-sm font-semibold ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'} mb-3`}>{t('demoUi.common.polarizationType')}</h4>
             <div className="grid grid-cols-3 gap-2">
               {(['linear', 'circular', 'elliptical'] as PolarizationType[]).map((type) => {
                 const colors = {
@@ -227,7 +229,7 @@ export function PolarizationTypesDemo() {
                     className={`py-2.5 px-3 rounded-lg text-sm font-medium border transition-all ${
                       polarizationType === type
                         ? colors[type].active
-                        : `bg-slate-700/50 text-gray-400 border-slate-600/50 ${colors[type].inactive}`
+                        : `${theme === 'dark' ? 'bg-slate-700/50 text-gray-400 border-slate-600/50' : 'bg-gray-100 text-gray-500 border-gray-300'} ${colors[type].inactive}`
                     }`}
                     whileHover={{ scale: 1.02 }}
                     whileTap={{ scale: 0.98 }}
@@ -259,13 +261,13 @@ export function PolarizationTypesDemo() {
 
           {(polarizationType === 'circular' || polarizationType === 'elliptical') && (
             <div className="space-y-2">
-              <span className="text-xs text-gray-400">{t('demoUi.common.rotationDirection')}</span>
+              <span className={`text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>{t('demoUi.common.rotationDirection')}</span>
               <div className="grid grid-cols-2 gap-2">
                 <motion.button
                   className={`py-2 rounded-lg text-sm font-medium border transition-all ${
                     circularDirection === 'right'
                       ? 'bg-green-400/20 text-green-400 border-green-400/50'
-                      : 'bg-slate-700/50 text-gray-400 border-slate-600/50 hover:border-green-400/30'
+                      : `${theme === 'dark' ? 'bg-slate-700/50 text-gray-400 border-slate-600/50' : 'bg-gray-100 text-gray-500 border-gray-300'} hover:border-green-400/30`
                   }`}
                   whileHover={{ scale: 1.02 }}
                   whileTap={{ scale: 0.98 }}
@@ -277,7 +279,7 @@ export function PolarizationTypesDemo() {
                   className={`py-2 rounded-lg text-sm font-medium border transition-all ${
                     circularDirection === 'left'
                       ? 'bg-purple-400/20 text-purple-400 border-purple-400/50'
-                      : 'bg-slate-700/50 text-gray-400 border-slate-600/50 hover:border-purple-400/30'
+                      : `${theme === 'dark' ? 'bg-slate-700/50 text-gray-400 border-slate-600/50' : 'bg-gray-100 text-gray-500 border-gray-300'} hover:border-purple-400/30`
                   }`}
                   whileHover={{ scale: 1.02 }}
                   whileTap={{ scale: 0.98 }}
@@ -317,9 +319,9 @@ export function PolarizationTypesDemo() {
                 type="checkbox"
                 checked={showTrail}
                 onChange={(e) => setShowTrail(e.target.checked)}
-                className="rounded border-gray-600 bg-slate-700 text-cyan-400"
+                className={`rounded ${theme === 'dark' ? 'border-gray-600 bg-slate-700' : 'border-gray-300 bg-white'} text-cyan-400`}
               />
-              <span className="text-sm text-gray-300">{t('demoUi.common.showTrail')}</span>
+              <span className={`text-sm ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>{t('demoUi.common.showTrail')}</span>
             </label>
           </div>
 
@@ -337,9 +339,9 @@ export function PolarizationTypesDemo() {
           </motion.button>
 
           {/* 物理意义 */}
-          <div className="pt-4 border-t border-slate-700 space-y-2">
-            <h4 className="text-sm font-semibold text-gray-300">{t('demoUi.common.physicalMeaning')}</h4>
-            <div className="text-xs text-gray-400 space-y-1">
+          <div className={`pt-4 border-t ${theme === 'dark' ? 'border-slate-700' : 'border-gray-200'} space-y-2`}>
+            <h4 className={`text-sm font-semibold ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}`}>{t('demoUi.common.physicalMeaning')}</h4>
+            <div className={`text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'} space-y-1`}>
               {polarizationType === 'linear' && (
                 <p>{t('demoUi.polarizationTypes.linearPhysics')}</p>
               )}
@@ -360,7 +362,7 @@ export function PolarizationTypesDemo() {
           title={t('demoUi.common.linearPolarization')}
           color={polarizationType === 'linear' ? 'orange' : 'cyan'}
         >
-          <p className="text-xs text-gray-300">
+          <p className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
             {t('demoUi.polarizationTypes.linearDesc')}
           </p>
         </InfoCard>
@@ -368,7 +370,7 @@ export function PolarizationTypesDemo() {
           title={t('demoUi.common.circularPolarization')}
           color={polarizationType === 'circular' ? 'green' : 'cyan'}
         >
-          <p className="text-xs text-gray-300">
+          <p className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
             {t('demoUi.polarizationTypes.circularDesc')}
           </p>
         </InfoCard>
@@ -376,7 +378,7 @@ export function PolarizationTypesDemo() {
           title={t('demoUi.common.ellipticalPolarization')}
           color={polarizationType === 'elliptical' ? 'purple' : 'cyan'}
         >
-          <p className="text-xs text-gray-300">
+          <p className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
             {t('demoUi.polarizationTypes.ellipticalDesc')}
           </p>
         </InfoCard>

--- a/src/components/demos/basics/PolarizationTypesUnifiedDemo.tsx
+++ b/src/components/demos/basics/PolarizationTypesUnifiedDemo.tsx
@@ -12,6 +12,7 @@
 import { useState, useMemo, useCallback, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/contexts/ThemeContext'
 import { Sparkles, FlaskConical, Volume2, VolumeX } from 'lucide-react'
 import { useHapticAudio } from '@/hooks/useHapticAudio'
 import {
@@ -174,6 +175,7 @@ interface Props {
 
 export function PolarizationTypesUnifiedDemo({ difficultyLevel = 'explore' }: Props) {
   const { i18n } = useTranslation()
+  const { theme } = useTheme()
   const isZh = i18n.language === 'zh'
   const config = useDifficultyConfig(difficultyLevel)
 
@@ -355,13 +357,13 @@ export function PolarizationTypesUnifiedDemo({ difficultyLevel = 'explore' }: Pr
   return (
     <div className="space-y-6">
       {/* View Mode Tabs */}
-      <div className="flex gap-2 p-1 bg-slate-800/50 rounded-lg w-fit">
+      <div className={`flex gap-2 p-1 ${theme === 'dark' ? 'bg-slate-800/50' : 'bg-gray-100'} rounded-lg w-fit`}>
         <button
           onClick={() => setViewMode('types')}
           className={`flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-all ${
             viewMode === 'types'
               ? 'bg-orange-500/20 text-orange-400 shadow-sm'
-              : 'text-gray-400 hover:text-gray-300 hover:bg-slate-700/50'
+              : `${theme === 'dark' ? 'text-gray-400 hover:text-gray-300 hover:bg-slate-700/50' : 'text-gray-500 hover:text-gray-700 hover:bg-gray-200'}`
           }`}
         >
           <Sparkles className="w-4 h-4" />
@@ -372,7 +374,7 @@ export function PolarizationTypesUnifiedDemo({ difficultyLevel = 'explore' }: Pr
           className={`flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-all ${
             viewMode === 'paradox'
               ? 'bg-purple-500/20 text-purple-400 shadow-sm'
-              : 'text-gray-400 hover:text-gray-300 hover:bg-slate-700/50'
+              : `${theme === 'dark' ? 'text-gray-400 hover:text-gray-300 hover:bg-slate-700/50' : 'text-gray-500 hover:text-gray-700 hover:bg-gray-200'}`
           }`}
         >
           <FlaskConical className="w-4 h-4" />
@@ -392,7 +394,7 @@ export function PolarizationTypesUnifiedDemo({ difficultyLevel = 'explore' }: Pr
             {/* Types View */}
             <div className="flex gap-6 flex-col lg:flex-row">
               <div className="flex-1">
-                <div className="bg-gradient-to-br from-slate-900 via-slate-900 to-indigo-950 rounded-xl border border-indigo-500/20 p-4">
+                <div className={`${theme === 'dark' ? 'bg-gradient-to-br from-slate-900 via-slate-900 to-indigo-950 border-indigo-500/20' : 'bg-gradient-to-br from-white via-gray-50 to-indigo-50 border-indigo-200'} rounded-xl border p-4`}>
                   <svg viewBox="0 0 400 400" className="w-full h-auto max-w-[400px] mx-auto">
                     <defs>
                       <filter id="glow-cyan">
@@ -439,8 +441,8 @@ export function PolarizationTypesUnifiedDemo({ difficultyLevel = 'explore' }: Pr
                 </div>
 
                 {/* Type selector */}
-                <div className="mt-4 p-4 rounded-lg bg-slate-800/50 border border-slate-700/50">
-                  <h4 className="text-sm font-semibold text-gray-300 mb-3">{isZh ? '偏振类型' : 'Polarization Type'}</h4>
+                <div className={`mt-4 p-4 rounded-lg ${theme === 'dark' ? 'bg-slate-800/50 border-slate-700/50' : 'bg-gray-50 border-gray-200'} border`}>
+                  <h4 className={`text-sm font-semibold ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'} mb-3`}>{isZh ? '偏振类型' : 'Polarization Type'}</h4>
                   <div className="grid grid-cols-3 gap-2">
                     {(['linear', 'circular', 'elliptical'] as PolarizationType[]).map((type) => {
                       const colors = {
@@ -456,7 +458,7 @@ export function PolarizationTypesUnifiedDemo({ difficultyLevel = 'explore' }: Pr
                           className={`py-2.5 px-3 rounded-lg text-sm font-medium border transition-all ${
                             polarizationType === type
                               ? colors[type].active
-                              : `bg-slate-700/50 text-gray-400 border-slate-600/50 ${colors[type].inactive}`
+                              : `${theme === 'dark' ? 'bg-slate-700/50 text-gray-400 border-slate-600/50' : 'bg-gray-100 text-gray-500 border-gray-300'} ${colors[type].inactive}`
                           }`}
                           whileHover={{ scale: 1.02 }}
                           whileTap={{ scale: 0.98 }}
@@ -486,13 +488,13 @@ export function PolarizationTypesUnifiedDemo({ difficultyLevel = 'explore' }: Pr
 
                 {(polarizationType === 'circular' || polarizationType === 'elliptical') && (
                   <div className="space-y-2">
-                    <span className="text-xs text-gray-400">{isZh ? '旋转方向' : 'Rotation Direction'}</span>
+                    <span className={`text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>{isZh ? '旋转方向' : 'Rotation Direction'}</span>
                     <div className="grid grid-cols-2 gap-2">
                       <motion.button
                         className={`py-2 rounded-lg text-sm font-medium border transition-all ${
                           circularDirection === 'right'
                             ? 'bg-green-400/20 text-green-400 border-green-400/50'
-                            : 'bg-slate-700/50 text-gray-400 border-slate-600/50'
+                            : `${theme === 'dark' ? 'bg-slate-700/50 text-gray-400 border-slate-600/50' : 'bg-gray-100 text-gray-500 border-gray-300'}`
                         }`}
                         whileHover={{ scale: 1.02 }}
                         onClick={() => setCircularDirection('right')}
@@ -503,7 +505,7 @@ export function PolarizationTypesUnifiedDemo({ difficultyLevel = 'explore' }: Pr
                         className={`py-2 rounded-lg text-sm font-medium border transition-all ${
                           circularDirection === 'left'
                             ? 'bg-purple-400/20 text-purple-400 border-purple-400/50'
-                            : 'bg-slate-700/50 text-gray-400 border-slate-600/50'
+                            : `${theme === 'dark' ? 'bg-slate-700/50 text-gray-400 border-slate-600/50' : 'bg-gray-100 text-gray-500 border-gray-300'}`
                         }`}
                         whileHover={{ scale: 1.02 }}
                         onClick={() => setCircularDirection('left')}
@@ -574,13 +576,13 @@ export function PolarizationTypesUnifiedDemo({ difficultyLevel = 'explore' }: Pr
             {/* Info cards */}
             <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
               <InfoCard title={isZh ? '线偏振' : 'Linear Polarization'} color={polarizationType === 'linear' ? 'orange' : 'cyan'}>
-                <p className="text-xs text-gray-300">{isZh ? '电场在固定平面内振荡，如同钟摆运动。' : 'E-field oscillates in a fixed plane, like a pendulum.'}</p>
+                <p className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>{isZh ? '电场在固定平面内振荡，如同钟摆运动。' : 'E-field oscillates in a fixed plane, like a pendulum.'}</p>
               </InfoCard>
               <InfoCard title={isZh ? '圆偏振' : 'Circular Polarization'} color={polarizationType === 'circular' ? 'green' : 'cyan'}>
-                <p className="text-xs text-gray-300">{isZh ? '电场矢量端点描绘圆形轨迹，等振幅、相位差90°。' : 'E-field tip traces a circle, equal amplitudes with 90° phase difference.'}</p>
+                <p className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>{isZh ? '电场矢量端点描绘圆形轨迹，等振幅、相位差90°。' : 'E-field tip traces a circle, equal amplitudes with 90° phase difference.'}</p>
               </InfoCard>
               <InfoCard title={isZh ? '椭圆偏振' : 'Elliptical Polarization'} color={polarizationType === 'elliptical' ? 'purple' : 'cyan'}>
-                <p className="text-xs text-gray-300">{isZh ? '最一般的偏振态，线偏振和圆偏振是特例。' : 'Most general state; linear and circular are special cases.'}</p>
+                <p className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>{isZh ? '最一般的偏振态，线偏振和圆偏振是特例。' : 'Most general state; linear and circular are special cases.'}</p>
               </InfoCard>
             </div>
           </motion.div>
@@ -607,7 +609,7 @@ export function PolarizationTypesUnifiedDemo({ difficultyLevel = 'explore' }: Pr
 
             <div className="flex gap-6 flex-col lg:flex-row">
               <div className="flex-1">
-                <div className="bg-gradient-to-br from-slate-900 via-slate-900 to-blue-950 rounded-xl border border-blue-500/20 p-4 overflow-hidden">
+                <div className={`${theme === 'dark' ? 'bg-gradient-to-br from-slate-900 via-slate-900 to-blue-950 border-blue-500/20' : 'bg-gradient-to-br from-white via-gray-50 to-blue-50 border-blue-200'} rounded-xl border p-4 overflow-hidden`}>
                   <svg viewBox="0 0 700 320" className="w-full h-auto" style={{ minHeight: '300px' }}>
                     <defs>
                       <pattern id="three-pol-grid" width="40" height="40" patternUnits="userSpaceOnUse">
@@ -705,10 +707,10 @@ export function PolarizationTypesUnifiedDemo({ difficultyLevel = 'explore' }: Pr
                   <Toggle label={isZh ? '偏振颜色' : 'Polarization Colors'} checked={showPolarization} onChange={setShowPolarization} />
                   <Toggle label={isZh ? '公式标注' : 'Show Formulas'} checked={showFormulas} onChange={setShowFormulas} />
 
-                  <div className="pt-2 border-t border-slate-700/50 mt-2">
+                  <div className={`pt-2 border-t ${theme === 'dark' ? 'border-slate-700/50' : 'border-gray-200'} mt-2`}>
                     <button onClick={toggleAudio}
                       className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm w-full transition-colors ${
-                        isAudioEnabled ? 'bg-cyan-500/20 text-cyan-400' : 'bg-slate-700/50 text-gray-400'
+                        isAudioEnabled ? 'bg-cyan-500/20 text-cyan-400' : `${theme === 'dark' ? 'bg-slate-700/50 text-gray-400' : 'bg-gray-100 text-gray-500'}`
                       }`}
                     >
                       {isAudioEnabled ? <Volume2 className="w-4 h-4" /> : <VolumeX className="w-4 h-4" />}
@@ -752,14 +754,14 @@ export function PolarizationTypesUnifiedDemo({ difficultyLevel = 'explore' }: Pr
             {/* Knowledge cards */}
             <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
               <InfoCard title={isZh ? '三偏振片悖论' : 'The Paradox'} color="purple">
-                <ul className="text-xs text-gray-300 space-y-1.5">
+                <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-1.5`}>
                   <li>• {isZh ? '两个正交偏振片完全阻挡光' : 'Crossed polarizers block all light'}</li>
                   <li>• {isZh ? '加入45°偏振片，反而有光通过！' : 'Adding 45° polarizer allows light through!'}</li>
                   <li>• {isZh ? '最大透射率：0°→45°→90° = 12.5%' : 'Max transmission: 0°→45°→90° = 12.5%'}</li>
                 </ul>
               </InfoCard>
               <InfoCard title={isZh ? '物理解释' : 'Physical Explanation'} color="cyan">
-                <ul className="text-xs text-gray-300 space-y-1.5">
+                <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-1.5`}>
                   <li>• {isZh ? '偏振片不只"过滤"，还"重新定向"' : 'Polarizers redirect, not just filter'}</li>
                   <li>• {isZh ? '中间片将0°偏振光转为45°' : 'Middle polarizer converts 0° to 45°'}</li>
                   <li>• {isZh ? '45°偏振光可部分通过90°偏振片' : '45° light can partially pass 90° polarizer'}</li>

--- a/src/components/demos/basics/ThreePolarizersDemo.tsx
+++ b/src/components/demos/basics/ThreePolarizersDemo.tsx
@@ -6,6 +6,7 @@
 import { useState, useMemo, useCallback, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/contexts/ThemeContext'
 import { Volume2, VolumeX } from 'lucide-react'
 import { useHapticAudio } from '@/hooks/useHapticAudio'
 import {
@@ -179,6 +180,7 @@ const PRESETS = [
 
 export function ThreePolarizersDemo() {
   const { i18n } = useTranslation()
+  const { theme } = useTheme()
   const isZh = i18n.language === 'zh'
 
   // Haptic audio for precision feedback
@@ -294,7 +296,7 @@ export function ThreePolarizersDemo() {
       <div className="flex gap-6 flex-col lg:flex-row">
         {/* 可视化区域 */}
         <div className="flex-1">
-          <div className="bg-gradient-to-br from-slate-900 via-slate-900 to-blue-950 rounded-xl border border-blue-500/20 p-4 overflow-hidden">
+          <div className={`${theme === 'dark' ? 'bg-gradient-to-br from-slate-900 via-slate-900 to-blue-950 border-blue-500/20' : 'bg-gradient-to-br from-white via-gray-50 to-blue-50 border-blue-200'} rounded-xl border p-4 overflow-hidden`}>
             <svg viewBox="0 0 700 320" className="w-full h-auto" style={{ minHeight: '300px' }}>
               <defs>
                 <pattern id="three-pol-grid" width="40" height="40" patternUnits="userSpaceOnUse">
@@ -627,13 +629,13 @@ export function ThreePolarizersDemo() {
             />
 
             {/* Audio Feedback Toggle */}
-            <div className="pt-2 border-t border-slate-700/50 mt-2">
+            <div className={`pt-2 border-t ${theme === 'dark' ? 'border-slate-700/50' : 'border-gray-200'} mt-2`}>
               <button
                 onClick={toggleAudio}
                 className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm w-full transition-colors ${
                   isAudioEnabled
                     ? 'bg-cyan-500/20 text-cyan-400 hover:bg-cyan-500/30'
-                    : 'bg-slate-700/50 text-gray-400 hover:bg-slate-700'
+                    : `${theme === 'dark' ? 'bg-slate-700/50 text-gray-400 hover:bg-slate-700' : 'bg-gray-100 text-gray-500 hover:bg-gray-200'}`
                 }`}
                 title={isZh ? '切换精密角度音效反馈' : 'Toggle precision angle audio feedback'}
               >
@@ -688,7 +690,7 @@ export function ThreePolarizersDemo() {
       {/* 知识卡片 */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <InfoCard title={isZh ? '三偏振片悖论' : 'Three Polarizer Paradox'} color="purple">
-          <ul className="text-xs text-gray-300 space-y-1.5">
+          <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-1.5`}>
             <li>
               •{' '}
               {isZh
@@ -717,7 +719,7 @@ export function ThreePolarizersDemo() {
         </InfoCard>
 
         <InfoCard title={isZh ? '物理解释' : 'Physical Explanation'} color="cyan">
-          <ul className="text-xs text-gray-300 space-y-1.5">
+          <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-1.5`}>
             <li>
               •{' '}
               {isZh

--- a/src/components/demos/source-code/LanguageSelector.tsx
+++ b/src/components/demos/source-code/LanguageSelector.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/contexts/ThemeContext'
 import { LANGUAGE_INFO, type SourceLanguage } from '@/types/source-code'
 import { motion } from 'framer-motion'
 
@@ -22,11 +23,12 @@ export function LanguageSelector({
   onLanguageChange,
 }: LanguageSelectorProps) {
   const { i18n } = useTranslation()
+  const { theme } = useTheme()
   const isZh = i18n.language === 'zh'
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex items-center gap-2 text-sm text-slate-400">
+      <div className={`flex items-center gap-2 text-sm ${theme === 'dark' ? 'text-slate-400' : 'text-gray-600'}`}>
         <span>{isZh ? '选择语言' : 'Choose Language'}:</span>
         <span className="text-xs">
           {isZh ? '同一演示的不同实现' : 'Different implementations of the same demo'}
@@ -48,8 +50,12 @@ export function LanguageSelector({
                 relative px-4 py-2.5 rounded-lg border-2 transition-all
                 ${
                   isSelected
-                    ? 'border-cyan-500 bg-cyan-500/10 text-white'
-                    : 'border-slate-700 bg-slate-800/50 text-slate-300 hover:border-slate-600'
+                    ? theme === 'dark'
+                      ? 'border-cyan-500 bg-cyan-500/10 text-white'
+                      : 'border-cyan-600 bg-cyan-50 text-cyan-700'
+                    : theme === 'dark'
+                      ? 'border-slate-700 bg-slate-800/50 text-slate-300 hover:border-slate-600'
+                      : 'border-gray-200 bg-gray-50 text-gray-700 hover:border-gray-300'
                 }
               `}
             >
@@ -102,7 +108,7 @@ export function LanguageSelector({
       </div>
 
       {/* Description of selected language */}
-      <div className="text-xs text-slate-500 mt-1">
+      <div className={`text-xs mt-1 ${theme === 'dark' ? 'text-slate-500' : 'text-gray-500'}`}>
         {isZh
           ? LANGUAGE_INFO[selectedLanguage].descriptionZh
           : LANGUAGE_INFO[selectedLanguage].description}

--- a/src/components/demos/source-code/SourceCodeViewer.tsx
+++ b/src/components/demos/source-code/SourceCodeViewer.tsx
@@ -64,10 +64,10 @@ export function SourceCodeViewer({
 
   if (!demoSource || !currentImpl) {
     return (
-      <div className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center">
-        <div className="bg-slate-900 p-8 rounded-xl text-white">
+      <div className="fixed inset-0 bg-black/50 dark:bg-black/80 z-50 flex items-center justify-center">
+        <div className="bg-white dark:bg-slate-900 p-8 rounded-xl text-gray-800 dark:text-white shadow-xl">
           <p>{isZh ? '未找到源码' : 'Source code not found'}</p>
-          <button onClick={onClose} className="mt-4 px-4 py-2 bg-cyan-600 rounded">
+          <button onClick={onClose} className="mt-4 px-4 py-2 bg-cyan-600 text-white rounded">
             {isZh ? '关闭' : 'Close'}
           </button>
         </div>
@@ -147,21 +147,21 @@ export function SourceCodeViewer({
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         onClick={onClose}
-        className="fixed inset-0 bg-black/90 z-50 flex items-center justify-center p-4 overflow-y-auto"
+        className="fixed inset-0 bg-black/50 dark:bg-black/90 z-50 flex items-center justify-center p-4 overflow-y-auto"
       >
         <motion.div
           initial={{ scale: 0.95, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
           exit={{ scale: 0.95, opacity: 0 }}
           onClick={e => e.stopPropagation()}
-          className="bg-slate-900 rounded-xl w-full max-w-6xl max-h-[95vh] flex flex-col shadow-2xl border border-slate-700"
+          className="bg-white dark:bg-slate-900 rounded-xl w-full max-w-6xl max-h-[95vh] flex flex-col shadow-2xl border border-gray-200 dark:border-slate-700"
         >
           {/* Header */}
-          <div className="flex items-start justify-between p-6 border-b border-slate-700">
+          <div className="flex items-start justify-between p-6 border-b border-gray-200 dark:border-slate-700">
             <div className="flex-1">
               <div className="flex items-center gap-3">
-                <FileCode className="w-6 h-6 text-cyan-400" />
-                <h2 className="text-2xl font-bold text-white">
+                <FileCode className="w-6 h-6 text-cyan-600 dark:text-cyan-400" />
+                <h2 className="text-2xl font-bold text-gray-800 dark:text-white">
                   {isZh ? demoSource.nameZh : demoSource.name}
                 </h2>
                 <span className={`px-2 py-1 rounded text-xs ${complexityColor}`}>
@@ -172,7 +172,7 @@ export function SourceCodeViewer({
                     : isZh ? '高级' : 'Advanced'}
                 </span>
               </div>
-              <p className="text-slate-400 mt-2 text-sm">
+              <p className="text-gray-600 dark:text-slate-400 mt-2 text-sm">
                 {isZh ? demoSource.descriptionZh : demoSource.description}
               </p>
 
@@ -181,7 +181,7 @@ export function SourceCodeViewer({
                 {(isZh ? demoSource.conceptsZh : demoSource.concepts).map((concept, idx) => (
                   <span
                     key={idx}
-                    className="px-2 py-1 bg-slate-800 text-slate-300 rounded text-xs"
+                    className="px-2 py-1 bg-gray-100 dark:bg-slate-800 text-gray-700 dark:text-slate-300 rounded text-xs"
                   >
                     {concept}
                   </span>
@@ -191,7 +191,7 @@ export function SourceCodeViewer({
 
             <button
               onClick={onClose}
-              className="ml-4 p-2 hover:bg-slate-800 rounded-lg transition-colors text-slate-400 hover:text-white"
+              className="ml-4 p-2 hover:bg-gray-100 dark:hover:bg-slate-800 rounded-lg transition-colors text-gray-500 dark:text-slate-400 hover:text-gray-700 dark:hover:text-white"
               aria-label="Close"
             >
               <X className="w-5 h-5" />
@@ -199,7 +199,7 @@ export function SourceCodeViewer({
           </div>
 
           {/* Language Selector */}
-          <div className="px-6 py-4 border-b border-slate-700 bg-slate-900/50">
+          <div className="px-6 py-4 border-b border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-900/50">
             <LanguageSelector
               availableLanguages={availableLanguages}
               selectedLanguage={selectedLanguage}
@@ -208,11 +208,11 @@ export function SourceCodeViewer({
           </div>
 
           {/* Toolbar */}
-          <div className="flex items-center justify-between px-6 py-3 border-b border-slate-700 bg-slate-900/50">
+          <div className="flex items-center justify-between px-6 py-3 border-b border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-900/50">
             <div className="flex items-center gap-2">
               <button
                 onClick={handleCopy}
-                className="flex items-center gap-2 px-3 py-2 bg-slate-800 hover:bg-slate-700 rounded-lg text-sm transition-colors"
+                className="flex items-center gap-2 px-3 py-2 bg-gray-200 dark:bg-slate-800 hover:bg-gray-300 dark:hover:bg-slate-700 text-gray-700 dark:text-gray-200 rounded-lg text-sm transition-colors"
               >
                 {copied ? (
                   <>
@@ -229,7 +229,7 @@ export function SourceCodeViewer({
 
               <button
                 onClick={handleDownloadSource}
-                className="flex items-center gap-2 px-3 py-2 bg-slate-800 hover:bg-slate-700 rounded-lg text-sm transition-colors"
+                className="flex items-center gap-2 px-3 py-2 bg-gray-200 dark:bg-slate-800 hover:bg-gray-300 dark:hover:bg-slate-700 text-gray-700 dark:text-gray-200 rounded-lg text-sm transition-colors"
               >
                 <Download className="w-4 h-4" />
                 <span>{isZh ? '下载源文件' : 'Download Source'}</span>
@@ -249,13 +249,13 @@ export function SourceCodeViewer({
               </button>
             </div>
 
-            <div className="text-xs text-slate-500">
+            <div className="text-xs text-gray-500 dark:text-slate-500">
               {languageInfo.icon} {isZh ? languageInfo.nameZh : languageInfo.name}
             </div>
           </div>
 
           {/* Code Display */}
-          <div className="flex-1 overflow-auto bg-slate-950 p-6">
+          <div className="flex-1 overflow-auto bg-gray-100 dark:bg-slate-950 p-6">
             {selectedLanguage === 'prompt' ? (
               // Special rendering for AI prompts with markdown styling
               <div className="prose prose-invert prose-sm max-w-none
@@ -311,30 +311,30 @@ export function SourceCodeViewer({
           </div>
 
           {/* Footer - Dependencies and Resources */}
-          <div className="border-t border-slate-700 bg-slate-900/50">
+          <div className="border-t border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-900/50">
             {/* Setup Instructions */}
             {currentImpl.setup && (
-              <div className="px-6 py-4 border-b border-slate-700">
-                <h3 className="text-sm font-semibold text-white mb-2 flex items-center gap-2">
+              <div className="px-6 py-4 border-b border-gray-200 dark:border-slate-700">
+                <h3 className="text-sm font-semibold text-gray-800 dark:text-white mb-2 flex items-center gap-2">
                   <BookOpen className="w-4 h-4" />
                   {isZh ? '安装说明' : 'Setup Instructions'}
                 </h3>
-                <pre className="text-xs text-slate-300 bg-slate-950 p-3 rounded overflow-x-auto">
+                <pre className="text-xs text-gray-700 dark:text-slate-300 bg-gray-100 dark:bg-slate-950 p-3 rounded overflow-x-auto">
                   {isZh ? currentImpl.setupZh || currentImpl.setup : currentImpl.setup}
                 </pre>
               </div>
             )}
 
             {/* Dependencies */}
-            <div className="px-6 py-4 border-b border-slate-700">
-              <h3 className="text-sm font-semibold text-white mb-2">
+            <div className="px-6 py-4 border-b border-gray-200 dark:border-slate-700">
+              <h3 className="text-sm font-semibold text-gray-800 dark:text-white mb-2">
                 {isZh ? '依赖项' : 'Dependencies'}:
               </h3>
               <div className="flex flex-wrap gap-2">
                 {Object.entries(currentImpl.dependencies).map(([name, version]) => (
                   <span
                     key={name}
-                    className="px-3 py-1 bg-slate-800 rounded text-xs text-slate-300 font-mono"
+                    className="px-3 py-1 bg-gray-200 dark:bg-slate-800 rounded text-xs text-gray-700 dark:text-slate-300 font-mono"
                   >
                     {name}
                     {typeof version === 'string' && version.match(/^[\d\^~>=<]/)
@@ -348,7 +348,7 @@ export function SourceCodeViewer({
             {/* Learning Resources */}
             {demoSource.resources && demoSource.resources.length > 0 && (
               <div className="px-6 py-4">
-                <h3 className="text-sm font-semibold text-white mb-3 flex items-center gap-2">
+                <h3 className="text-sm font-semibold text-gray-800 dark:text-white mb-3 flex items-center gap-2">
                   <BookOpen className="w-4 h-4" />
                   {isZh ? '学习资源' : 'Learning Resources'}
                 </h3>
@@ -359,10 +359,10 @@ export function SourceCodeViewer({
                       href={resource.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="flex items-center gap-2 px-3 py-2 bg-slate-800 hover:bg-slate-700 rounded text-sm transition-colors group"
+                      className="flex items-center gap-2 px-3 py-2 bg-gray-200 dark:bg-slate-800 hover:bg-gray-300 dark:hover:bg-slate-700 rounded text-sm transition-colors group"
                     >
-                      <ExternalLink className="w-3 h-3 text-cyan-400 group-hover:text-cyan-300" />
-                      <span className="text-slate-300 group-hover:text-white text-xs">
+                      <ExternalLink className="w-3 h-3 text-cyan-600 dark:text-cyan-400 group-hover:text-cyan-700 dark:group-hover:text-cyan-300" />
+                      <span className="text-gray-700 dark:text-slate-300 group-hover:text-gray-900 dark:group-hover:text-white text-xs">
                         {isZh ? resource.titleZh || resource.title : resource.title}
                       </span>
                     </a>
@@ -373,8 +373,8 @@ export function SourceCodeViewer({
 
             {/* Notes */}
             {currentImpl.notes && (
-              <div className="px-6 py-4 border-t border-slate-700 bg-slate-900">
-                <p className="text-xs text-slate-400 italic">
+              <div className="px-6 py-4 border-t border-gray-200 dark:border-slate-700 bg-gray-100 dark:bg-slate-900">
+                <p className="text-xs text-gray-600 dark:text-slate-400 italic">
                   💡 {isZh ? currentImpl.notesZh || currentImpl.notes : currentImpl.notes}
                 </p>
               </div>

--- a/src/components/demos/unit1/AragoFresnelDemo.tsx
+++ b/src/components/demos/unit1/AragoFresnelDemo.tsx
@@ -23,6 +23,7 @@ import {
   Toggle,
   ValueDisplay,
 } from '../DemoControls'
+import { useTheme } from '@/contexts/ThemeContext'
 
 // 计算干涉条纹强度
 function calculateInterferencePattern(
@@ -473,6 +474,7 @@ function PolarizationVectorDiagram({
 // 主演示组件
 export function AragoFresnelDemo() {
   const { t } = useTranslation()
+  const { theme } = useTheme()
 
   // 状态
   const [pol1, setPol1] = useState(0)      // 光束1偏振角
@@ -509,7 +511,7 @@ export function AragoFresnelDemo() {
         <h2 className="text-2xl font-bold bg-gradient-to-r from-white via-pink-100 to-white bg-clip-text text-transparent">
           {t('demoUi.aragoFresnel.title') || '阿拉戈-菲涅尔定律'}
         </h2>
-        <p className="text-gray-400 mt-1">
+        <p className={`mt-1 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
           {t('demoUi.aragoFresnel.subtitle') || '正交偏振光的干涉与检偏器的作用'}
         </p>
       </div>
@@ -522,7 +524,7 @@ export function AragoFresnelDemo() {
             className={`px-4 py-2 rounded-lg text-sm font-medium border transition-all ${
               pol1 === preset.pol1 && pol2 === preset.pol2 && showAnalyzer === preset.analyzer
                 ? 'bg-cyan-500/20 text-cyan-400 border-cyan-500/50'
-                : 'bg-slate-800/50 text-gray-400 border-slate-600/50 hover:border-slate-500'
+                : theme === 'dark' ? 'bg-slate-800/50 text-gray-400 border-slate-600/50 hover:border-slate-500' : 'bg-gray-100/50 text-gray-600 border-gray-300/50 hover:border-gray-400'
             }`}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
@@ -543,8 +545,8 @@ export function AragoFresnelDemo() {
         {/* 左侧：光路图和干涉图样 */}
         <div className="lg:col-span-2 space-y-4">
           {/* 光路示意图 */}
-          <div className="rounded-xl bg-gradient-to-br from-slate-900/90 via-slate-900/95 to-pink-950/90 border border-pink-500/30 p-4">
-            <h3 className="text-sm font-semibold text-white mb-3">光路示意图</h3>
+          <div className={`rounded-xl border border-pink-500/30 p-4 ${theme === 'dark' ? 'bg-gradient-to-br from-slate-900/90 via-slate-900/95 to-pink-950/90' : 'bg-gradient-to-br from-white via-gray-50 to-pink-50'}`}>
+            <h3 className={`text-sm font-semibold mb-3 ${theme === 'dark' ? 'text-white' : 'text-gray-900'}`}>光路示意图</h3>
             <OpticalSetupDiagram
               pol1={pol1}
               pol2={pol2}
@@ -555,9 +557,9 @@ export function AragoFresnelDemo() {
           </div>
 
           {/* 干涉图样 */}
-          <div className="rounded-xl bg-slate-900/80 border border-slate-600/30 p-4">
+          <div className={`rounded-xl border p-4 ${theme === 'dark' ? 'bg-slate-900/80 border-slate-600/30' : 'bg-white border-gray-200'}`}>
             <div className="flex items-center justify-between mb-3">
-              <h3 className="text-sm font-semibold text-white">干涉图样</h3>
+              <h3 className={`text-sm font-semibold ${theme === 'dark' ? 'text-white' : 'text-gray-900'}`}>干涉图样</h3>
               <div className={`px-3 py-1 rounded-full text-xs font-medium ${
                 visibility > 0.5 ? 'bg-green-500/20 text-green-400' :
                 visibility > 0.1 ? 'bg-yellow-500/20 text-yellow-400' :
@@ -631,8 +633,8 @@ export function AragoFresnelDemo() {
             />
 
             {/* 检偏器开关 */}
-            <div className="flex items-center justify-between py-2 border-t border-slate-700/50">
-              <span className="text-xs text-gray-400">启用检偏器</span>
+            <div className={`flex items-center justify-between py-2 border-t ${theme === 'dark' ? 'border-slate-700/50' : 'border-gray-200'}`}>
+              <span className={`text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>启用检偏器</span>
               <Toggle
                 label=""
                 checked={showAnalyzer}
@@ -659,7 +661,7 @@ export function AragoFresnelDemo() {
               className={`w-full mt-2 px-4 py-2 rounded-lg text-sm font-medium transition-all ${
                 animate
                   ? 'bg-pink-400/20 text-pink-400 border border-pink-400/50'
-                  : 'bg-slate-700/50 text-gray-400 border border-slate-600'
+                  : theme === 'dark' ? 'bg-slate-700/50 text-gray-400 border border-slate-600' : 'bg-gray-100 text-gray-600 border border-gray-300'
               }`}
               whileHover={{ scale: 1.02 }}
               whileTap={{ scale: 0.98 }}
@@ -716,24 +718,24 @@ export function AragoFresnelDemo() {
       </div>
 
       {/* 公式说明 */}
-      <div className="bg-slate-900/50 rounded-xl border border-slate-700/50 p-4">
-        <h3 className="text-sm font-semibold text-white mb-3">干涉公式</h3>
+      <div className={`rounded-xl border p-4 ${theme === 'dark' ? 'bg-slate-900/50 border-slate-700/50' : 'bg-gray-50 border-gray-200'}`}>
+        <h3 className={`text-sm font-semibold mb-3 ${theme === 'dark' ? 'text-white' : 'text-gray-900'}`}>干涉公式</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs">
-          <div className="p-3 bg-slate-800/50 rounded-lg">
+          <div className={`p-3 rounded-lg ${theme === 'dark' ? 'bg-slate-800/50' : 'bg-white'}`}>
             <div className="font-mono text-cyan-400 mb-1">无检偏器时:</div>
-            <div className="text-gray-300">
+            <div className={theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}>
               I = I₁ + I₂ + 2√(I₁I₂)·cos(δ)·cos²(Δθ/2)
             </div>
-            <div className="text-gray-500 mt-1">
+            <div className={`mt-1 ${theme === 'dark' ? 'text-gray-500' : 'text-gray-600'}`}>
               当 Δθ = 90° 时，cos²(45°) = 0.5，干涉项消失
             </div>
           </div>
-          <div className="p-3 bg-slate-800/50 rounded-lg">
+          <div className={`p-3 rounded-lg ${theme === 'dark' ? 'bg-slate-800/50' : 'bg-white'}`}>
             <div className="font-mono text-purple-400 mb-1">有检偏器时:</div>
-            <div className="text-gray-300">
+            <div className={theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}>
               I = |E₁·cos(θ₁-α) + E₂·cos(θ₂-α)·e^(iδ)|²
             </div>
-            <div className="text-gray-500 mt-1">
+            <div className={`mt-1 ${theme === 'dark' ? 'text-gray-500' : 'text-gray-600'}`}>
               检偏器角度 α 将两束光投影到同一方向
             </div>
           </div>

--- a/src/components/demos/unit1/BirefringenceDemo.tsx
+++ b/src/components/demos/unit1/BirefringenceDemo.tsx
@@ -21,6 +21,7 @@ import {
   SideBySideComparison,
 } from '@/components/real-experiments'
 import { getResourcesByModule } from '@/data/resource-gallery'
+import { useTheme } from '@/contexts/ThemeContext'
 
 // 光源组件
 function LightSource({ position }: { position: [number, number, number] }) {
@@ -412,6 +413,7 @@ function TabButton({
 // 主演示组件
 export function BirefringenceDemo() {
   const { i18n } = useTranslation()
+  const { theme } = useTheme()
   const isZh = i18n.language === 'zh'
 
   const [activeTab, setActiveTab] = useState<DemoTab>('theory')
@@ -436,7 +438,7 @@ export function BirefringenceDemo() {
         <h2 className="text-2xl font-bold bg-gradient-to-r from-white via-cyan-100 to-white bg-clip-text text-transparent">
           {isZh ? '双折射效应 - 3D交互' : 'Birefringence - 3D Interactive'}
         </h2>
-        <p className="text-gray-400 mt-1">
+        <p className={`mt-1 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
           {isZh
             ? '方解石晶体将一束光分裂为偏振方向垂直的o光和e光 · 拖动旋转视角'
             : 'Calcite crystal splits light into o-ray and e-ray with perpendicular polarizations'}
@@ -472,7 +474,7 @@ export function BirefringenceDemo() {
             className="flex flex-col gap-6"
           >
             {/* 3D可视化面板 */}
-            <div className="bg-slate-900/50 rounded-xl border border-cyan-400/20 overflow-hidden" style={{ height: 400 }}>
+            <div className={`rounded-xl border border-cyan-400/20 overflow-hidden ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-50'}`} style={{ height: 400 }}>
               <Canvas
                 camera={{ position: [0, 2, 8], fov: 50 }}
                 gl={{ antialias: true, pixelRatio: Math.min(window.devicePixelRatio, 2) }}
@@ -611,14 +613,14 @@ export function BirefringenceDemo() {
             className="flex flex-col gap-6"
           >
             {/* Real World Lab content */}
-            <div className="bg-slate-900/50 rounded-xl border border-emerald-400/20 p-4">
+            <div className={`rounded-xl border border-emerald-400/20 p-4 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-50'}`}>
               <div className="flex items-center gap-2 mb-4">
                 <Beaker className="w-5 h-5 text-emerald-400" />
-                <h3 className="text-lg font-semibold text-white">
+                <h3 className={`text-lg font-semibold ${theme === 'dark' ? 'text-white' : 'text-gray-900'}`}>
                   {isZh ? '厚度与干涉色实验' : 'Thickness & Interference Color Experiment'}
                 </h3>
               </div>
-              <p className="text-gray-400 text-sm mb-4">
+              <p className={`text-sm mb-4 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
                 {isZh
                   ? '在正交偏振系统中，双折射材料的厚度直接影响观察到的干涉色。增加保鲜膜层数，观察颜色如何变化！'
                   : 'In crossed polarizers, the thickness of birefringent materials directly affects the observed interference colors. Add layers of plastic wrap and observe the color changes!'}
@@ -627,14 +629,14 @@ export function BirefringenceDemo() {
             </div>
 
             {/* Real vs Simulation Comparison */}
-            <div className="bg-slate-900/50 rounded-xl border border-cyan-400/20 p-4">
+            <div className={`rounded-xl border border-cyan-400/20 p-4 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-50'}`}>
               <div className="flex items-center gap-2 mb-4">
                 <Box className="w-5 h-5 text-cyan-400" />
-                <h3 className="text-lg font-semibold text-white">
+                <h3 className={`text-lg font-semibold ${theme === 'dark' ? 'text-white' : 'text-gray-900'}`}>
                   {isZh ? '双折射对比演示' : 'Birefringence Comparison Demo'}
                 </h3>
               </div>
-              <p className="text-gray-400 text-sm mb-4">
+              <p className={`text-sm mb-4 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
                 {isZh
                   ? '拖动中间分割线，对比真实双折射实验与3D模拟器。调整参数查看相似度匹配！'
                   : 'Drag the center divider to compare real birefringence experiment with 3D simulator. Adjust parameters to see similarity matching!'}
@@ -714,14 +716,14 @@ export function BirefringenceDemo() {
             </div>
 
             {/* Stress comparison */}
-            <div className="bg-slate-900/50 rounded-xl border border-purple-400/20 p-4">
+            <div className={`rounded-xl border border-purple-400/20 p-4 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-50'}`}>
               <div className="flex items-center gap-2 mb-4">
                 <FlaskConical className="w-5 h-5 text-purple-400" />
-                <h3 className="text-lg font-semibold text-white">
+                <h3 className={`text-lg font-semibold ${theme === 'dark' ? 'text-white' : 'text-gray-900'}`}>
                   {isZh ? '玻璃应力对比' : 'Glass Stress Comparison'}
                 </h3>
               </div>
-              <p className="text-gray-400 text-sm mb-4">
+              <p className={`text-sm mb-4 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
                 {isZh
                   ? '钢化玻璃经过热处理产生预应力，在正交偏振下显示特征图案。拖动滑块对比钢化玻璃和普通玻璃的差异！'
                   : 'Tempered glass has pre-stress from heat treatment, showing characteristic patterns under crossed polarizers. Drag the slider to compare tempered and ordinary glass!'}

--- a/src/components/demos/unit1/MalusLawDemo.tsx
+++ b/src/components/demos/unit1/MalusLawDemo.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from 'react-i18next'
 import { SliderControl, ControlPanel, InfoCard } from '../DemoControls'
 import { RealExperimentMicroGallery } from '@/components/real-experiments'
 import { DifficultyLevel } from '../DifficultyStrategy'
+import { useTheme } from '@/contexts/ThemeContext'
 
 // 组件属性接口
 interface MalusLawDemoProps {
@@ -372,6 +373,7 @@ function MalusCurveChart({ currentAngle, intensity }: { currentAngle: number; in
 // 主组件
 export function MalusLawDemo({ difficultyLevel = 'explore' }: MalusLawDemoProps) {
   const { t } = useTranslation()
+  const { theme } = useTheme()
   const [angle, setAngle] = useState(30)
   const [incidentIntensity, setIncidentIntensity] = useState(1)
   const [autoPlay, setAutoPlay] = useState(false)
@@ -429,7 +431,7 @@ export function MalusLawDemo({ difficultyLevel = 'explore' }: MalusLawDemoProps)
         <h2 className="text-2xl font-bold bg-gradient-to-r from-white via-blue-100 to-white bg-clip-text text-transparent">
           {t('demoUi.malus.title')}
         </h2>
-        <p className="text-gray-400 mt-1">
+        <p className={`mt-1 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
           {t('demoUi.malus.subtitle')}
         </p>
       </div>
@@ -437,11 +439,11 @@ export function MalusLawDemo({ difficultyLevel = 'explore' }: MalusLawDemoProps)
       {/* 主体内容 */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* 左侧：可视化 */}
-        <div className="rounded-xl bg-gradient-to-br from-slate-900/90 via-slate-900/95 to-blue-950/90 border border-blue-500/30 p-5 shadow-[0_15px_40px_rgba(0,0,0,0.5)]">
-          <h3 className="text-lg font-semibold text-white mb-4">{t('demoUi.malus.visualization')}</h3>
+        <div className={`rounded-xl border border-blue-500/30 p-5 shadow-[0_15px_40px_rgba(0,0,0,0.5)] ${theme === 'dark' ? 'bg-gradient-to-br from-slate-900/90 via-slate-900/95 to-blue-950/90' : 'bg-gradient-to-br from-white via-gray-50 to-blue-50'}`}>
+          <h3 className={`text-lg font-semibold mb-4 ${theme === 'dark' ? 'text-white' : 'text-gray-900'}`}>{t('demoUi.malus.visualization')}</h3>
 
           {/* 光学装置 */}
-          <div className="rounded-lg bg-gradient-to-br from-slate-800/50 to-slate-900/50 border border-blue-400/30 p-4 space-y-4">
+          <div className={`rounded-lg border border-blue-400/30 p-4 space-y-4 ${theme === 'dark' ? 'bg-gradient-to-br from-slate-800/50 to-slate-900/50' : 'bg-gradient-to-br from-gray-100/50 to-gray-200/50'}`}>
             {/* 入射光 */}
             <LightBar label="I₀" intensity={incidentIntensity} color="blue" />
 
@@ -481,17 +483,17 @@ export function MalusLawDemo({ difficultyLevel = 'explore' }: MalusLawDemoProps)
           </div>
 
           {/* 解释框 */}
-          <div className="mt-4 p-4 rounded-lg bg-slate-800/70 border border-blue-400/20">
-            <h4 className="text-sm font-semibold text-white mb-2">{t('demoUi.malus.currentMeaning')}</h4>
+          <div className={`mt-4 p-4 rounded-lg border border-blue-400/20 ${theme === 'dark' ? 'bg-slate-800/70' : 'bg-gray-100/70'}`}>
+            <h4 className={`text-sm font-semibold mb-2 ${theme === 'dark' ? 'text-white' : 'text-gray-900'}`}>{t('demoUi.malus.currentMeaning')}</h4>
             <motion.p
-              className="text-sm text-gray-300"
+              className={`text-sm ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}`}
               key={Math.floor(angle / 10)}
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
             >
               {getExplanation(angle)}
             </motion.p>
-            <p className="text-xs text-gray-500 mt-2">
+            <p className={`text-xs mt-2 ${theme === 'dark' ? 'text-gray-500' : 'text-gray-600'}`}>
               {t('demoUi.malus.assumption')}
             </p>
           </div>
@@ -526,7 +528,7 @@ export function MalusLawDemo({ difficultyLevel = 'explore' }: MalusLawDemoProps)
 
             {/* 研究级别: 消光比参数 */}
             {isResearch && (
-              <div className="pt-2 border-t border-slate-700/50">
+              <div className={`pt-2 border-t ${theme === 'dark' ? 'border-slate-700/50' : 'border-gray-200'}`}>
                 <SliderControl
                   label="消光比 (ER)"
                   value={Math.log10(extinctionRatio)}
@@ -536,7 +538,7 @@ export function MalusLawDemo({ difficultyLevel = 'explore' }: MalusLawDemoProps)
                   onChange={(v) => setExtinctionRatio(Math.pow(10, v))}
                   color="cyan"
                 />
-                <p className="text-[10px] text-gray-500 mt-1">
+                <p className={`text-[10px] mt-1 ${theme === 'dark' ? 'text-gray-500' : 'text-gray-600'}`}>
                   ER = 10^{Math.log10(extinctionRatio).toFixed(1)} ≈ {extinctionRatio.toFixed(0)}
                   {extinctionRatio >= 10000 ? ' (高品质)' : extinctionRatio >= 100 ? ' (普通)' : ' (低品质)'}
                 </p>
@@ -589,29 +591,29 @@ export function MalusLawDemo({ difficultyLevel = 'explore' }: MalusLawDemoProps)
               </div>
 
               <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
-                <div className="text-gray-400">
+                <div className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>
                   I₀ = <span className="text-cyan-400 font-mono">{incidentIntensity.toFixed(3)}</span>
                 </div>
-                <div className="text-gray-400">
+                <div className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>
                   θ = <span className="text-purple-400 font-mono">{angle.toFixed(2)}°</span>
                 </div>
-                <div className="text-gray-400">
+                <div className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>
                   cos θ ≈ <span className="text-cyan-400 font-mono">{cosTheta.toFixed(4)}</span>
                 </div>
-                <div className="text-gray-400">
+                <div className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>
                   cos²θ ≈ <span className="text-cyan-400 font-mono">{cos2Theta.toFixed(4)}</span>
                 </div>
                 {isResearch && (
                   <>
-                    <div className="text-gray-400">
+                    <div className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>
                       sin²θ ≈ <span className="text-cyan-400 font-mono">{sin2Theta.toFixed(4)}</span>
                     </div>
-                    <div className="text-gray-400">
+                    <div className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>
                       sin²θ/ER ≈ <span className="text-cyan-400 font-mono">{(sin2Theta / extinctionRatio).toFixed(6)}</span>
                     </div>
                   </>
                 )}
-                <div className="col-span-2 text-gray-400 pt-1 border-t border-slate-700 mt-1">
+                <div className={`col-span-2 pt-1 mt-1 border-t ${theme === 'dark' ? 'text-gray-400 border-slate-700' : 'text-gray-600 border-gray-200'}`}>
                   {isResearch ? (
                     <>
                       I = I₀ · [cos²θ + sin²θ/ER] ≈{' '}
@@ -628,7 +630,7 @@ export function MalusLawDemo({ difficultyLevel = 'explore' }: MalusLawDemoProps)
                     </>
                   )}
                 </div>
-                <div className="col-span-2 text-gray-400">
+                <div className={`col-span-2 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
                   I/I₀ ≈{' '}
                   <span className="text-orange-400 font-mono font-semibold">{(transmittedIntensity / incidentIntensity).toFixed(4)}</span>
                   {isResearch && Math.abs(angle - 90) < 5 && (
@@ -654,18 +656,18 @@ export function MalusLawDemo({ difficultyLevel = 'explore' }: MalusLawDemoProps)
           {isFoundation && (
             <ControlPanel title="简单理解">
               <div className="space-y-3">
-                <div className="p-3 rounded-lg bg-slate-800/50">
-                  <p className="text-sm text-gray-300">
+                <div className={`p-3 rounded-lg ${theme === 'dark' ? 'bg-slate-800/50' : 'bg-gray-100/50'}`}>
+                  <p className={`text-sm ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}`}>
                     当两个偏振片的角度<strong className="text-cyan-400">相同</strong>时，光可以<strong className="text-green-400">完全通过</strong>。
                   </p>
                 </div>
-                <div className="p-3 rounded-lg bg-slate-800/50">
-                  <p className="text-sm text-gray-300">
+                <div className={`p-3 rounded-lg ${theme === 'dark' ? 'bg-slate-800/50' : 'bg-gray-100/50'}`}>
+                  <p className={`text-sm ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}`}>
                     当两个偏振片的角度<strong className="text-purple-400">相差90°</strong>时，光会被<strong className="text-red-400">完全阻挡</strong>。
                   </p>
                 </div>
-                <div className="p-3 rounded-lg bg-slate-800/50">
-                  <p className="text-sm text-gray-300">
+                <div className={`p-3 rounded-lg ${theme === 'dark' ? 'bg-slate-800/50' : 'bg-gray-100/50'}`}>
+                  <p className={`text-sm ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}`}>
                     其他角度时，通过的光量在0%到100%之间变化。
                   </p>
                 </div>
@@ -673,7 +675,7 @@ export function MalusLawDemo({ difficultyLevel = 'explore' }: MalusLawDemoProps)
                   <span className="text-2xl font-bold text-orange-400">
                     {(transmittedIntensity * 100).toFixed(0)}%
                   </span>
-                  <span className="text-gray-400 text-sm ml-2">的光通过</span>
+                  <span className={`text-sm ml-2 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>的光通过</span>
                 </div>
               </div>
             </ControlPanel>
@@ -683,7 +685,7 @@ export function MalusLawDemo({ difficultyLevel = 'explore' }: MalusLawDemoProps)
           {!isFoundation && (
             <ControlPanel title={t('demoUi.malus.curveTitle')}>
               <MalusCurveChart currentAngle={angle} intensity={isResearch ? transmittedIntensity / incidentIntensity : cos2Theta} />
-              <p className="text-xs text-gray-400 mt-2">
+              <p className={`text-xs mt-2 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
                 {t('demoUi.malus.curveDesc')}
                 {isResearch && ' 注意: 非理想偏振片在90°处仍有微小透射。'}
               </p>
@@ -693,8 +695,8 @@ export function MalusLawDemo({ difficultyLevel = 'explore' }: MalusLawDemoProps)
       </div>
 
       {/* 底部提示 */}
-      <div className="p-4 rounded-lg bg-slate-800/50 border border-slate-700/50">
-        <p className="text-sm text-gray-400">
+      <div className={`p-4 rounded-lg border ${theme === 'dark' ? 'bg-slate-800/50 border-slate-700/50' : 'bg-gray-100/50 border-gray-200'}`}>
+        <p className={`text-sm ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
           <strong className="text-cyan-400">{t('demoUi.common.learningTip')}：</strong>
           {t('demoUi.malus.tip')}
         </p>

--- a/src/components/demos/unit1/PolarizationStateDemo.tsx
+++ b/src/components/demos/unit1/PolarizationStateDemo.tsx
@@ -12,6 +12,7 @@ import {
   Formula,
   InfoCard,
 } from '../DemoControls'
+import { useTheme } from '@/contexts/ThemeContext'
 
 // 3D波动传播视图 - 伪3D等轴测投影Canvas
 function WavePropagation3DCanvas({
@@ -404,6 +405,7 @@ function PresetButton({
 
 // 主演示组件
 export function PolarizationStateDemo() {
+  const { theme } = useTheme()
   const [phaseDiff, setPhaseDiff] = useState(0)
   const [ampX, setAmpX] = useState(1)
   const [ampY, setAmpY] = useState(1)
@@ -449,7 +451,7 @@ export function PolarizationStateDemo() {
         <h2 className="text-2xl font-bold bg-gradient-to-r from-white via-cyan-100 to-white bg-clip-text text-transparent">
           偏振态与波合成
         </h2>
-        <p className="text-gray-400 mt-1">
+        <p className={`mt-1 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
           探索光的偏振状态：由两个垂直分量的振幅比和相位差决定
         </p>
       </div>
@@ -457,10 +459,10 @@ export function PolarizationStateDemo() {
       {/* 上方：两个可视化面板 */}
       <div className="flex flex-col lg:flex-row gap-6">
         {/* 3D 波动传播视图 */}
-        <div className="flex-1 bg-slate-900/50 rounded-xl border border-cyan-400/20 overflow-hidden">
+        <div className={`flex-1 rounded-xl border border-cyan-400/20 overflow-hidden ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-50'}`}>
           <div className="px-4 py-3 border-b border-cyan-400/10 flex items-center justify-between">
-            <h3 className="text-sm font-semibold text-white">3D 空间传播视图</h3>
-            <div className="text-xs text-gray-500">伪等轴测投影</div>
+            <h3 className={`text-sm font-semibold ${theme === 'dark' ? 'text-white' : 'text-gray-900'}`}>3D 空间传播视图</h3>
+            <div className={`text-xs ${theme === 'dark' ? 'text-gray-500' : 'text-gray-600'}`}>伪等轴测投影</div>
           </div>
           <div className="p-4 flex justify-center">
             <WavePropagation3DCanvas
@@ -473,9 +475,9 @@ export function PolarizationStateDemo() {
         </div>
 
         {/* 2D 偏振态投影 */}
-        <div className="lg:w-[360px] bg-slate-900/50 rounded-xl border border-cyan-400/20 overflow-hidden">
+        <div className={`lg:w-[360px] rounded-xl border border-cyan-400/20 overflow-hidden ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-50'}`}>
           <div className="px-4 py-3 border-b border-cyan-400/10">
-            <h3 className="text-sm font-semibold text-white">偏振态投影</h3>
+            <h3 className={`text-sm font-semibold ${theme === 'dark' ? 'text-white' : 'text-gray-900'}`}>偏振态投影</h3>
           </div>
           <div className="p-4 flex flex-col items-center gap-3">
             <PolarizationStateCanvas
@@ -486,19 +488,19 @@ export function PolarizationStateDemo() {
             />
             <div className="text-center space-y-1">
               <div>
-                <span className="text-gray-400 text-sm">当前状态: </span>
+                <span className={`text-sm ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>当前状态: </span>
                 <span className="font-semibold" style={{ color: polarizationState.color }}>
                   {polarizationState.type}
                 </span>
               </div>
-              <p className="text-xs text-gray-500">{polarizationState.description}</p>
+              <p className={`text-xs ${theme === 'dark' ? 'text-gray-500' : 'text-gray-600'}`}>{polarizationState.description}</p>
             </div>
           </div>
         </div>
       </div>
 
       {/* 快速预设 */}
-      <div className="bg-slate-900/50 rounded-xl border border-cyan-400/20 p-4">
+      <div className={`rounded-xl border border-cyan-400/20 p-4 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-50'}`}>
         <div className="flex flex-wrap gap-2 justify-center">
           {presets.map((preset, index) => (
             <PresetButton
@@ -514,7 +516,7 @@ export function PolarizationStateDemo() {
             className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
               animate
                 ? 'bg-cyan-400/20 text-cyan-400 border border-cyan-400/50'
-                : 'bg-slate-700/50 text-gray-400 border border-slate-600'
+                : theme === 'dark' ? 'bg-slate-700/50 text-gray-400 border border-slate-600' : 'bg-gray-100 text-gray-600 border border-gray-300'
             }`}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
@@ -580,7 +582,7 @@ export function PolarizationStateDemo() {
 
         {/* 物理原理 */}
         <ControlPanel title="物理原理">
-          <div className="text-xs text-gray-400 space-y-2">
+          <div className={`text-xs space-y-2 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
             <p>
               <strong className="text-cyan-400">偏振态</strong>
               由两个互相垂直的电场分量 (Ex, Ey) 的振幅比和相位差(δ)决定。

--- a/src/components/demos/unit1/WaveplateDemo.tsx
+++ b/src/components/demos/unit1/WaveplateDemo.tsx
@@ -19,6 +19,7 @@ import {
   Formula,
   Toggle,
 } from '../DemoControls'
+import { useTheme } from '@/contexts/ThemeContext'
 import {
   JonesMatrix,
   JonesVector,
@@ -618,6 +619,7 @@ function calculateNonIdealOutput(
 
 // 主演示组件
 export function WaveplateDemo() {
+  const { theme } = useTheme()
   const [waveplateType, setWaveplateType] = useState<WaveplateType>('quarter')
   const [inputAngle, setInputAngle] = useState(45)
   const [fastAxisAngle, setFastAxisAngle] = useState(0)
@@ -691,7 +693,7 @@ export function WaveplateDemo() {
         <h2 className="text-2xl font-bold bg-gradient-to-r from-white via-cyan-100 to-white bg-clip-text text-transparent">
           波片原理
         </h2>
-        <p className="text-gray-400 mt-1">
+        <p className={`mt-1 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
           λ/4和λ/2波片如何改变光的偏振态
         </p>
       </div>
@@ -702,7 +704,7 @@ export function WaveplateDemo() {
           className={`px-4 py-1.5 rounded-lg text-xs font-medium border transition-all ${
             difficultyLevel === 'basic'
               ? 'bg-green-500/20 text-green-400 border-green-500/50'
-              : 'bg-slate-800/50 text-gray-400 border-slate-600/50 hover:border-slate-500'
+              : theme === 'dark' ? 'bg-slate-800/50 text-gray-400 border-slate-600/50 hover:border-slate-500' : 'bg-gray-100/50 text-gray-600 border-gray-300/50 hover:border-gray-400'
           }`}
           whileHover={{ scale: 1.02 }}
           whileTap={{ scale: 0.98 }}
@@ -714,7 +716,7 @@ export function WaveplateDemo() {
           className={`px-4 py-1.5 rounded-lg text-xs font-medium border transition-all ${
             difficultyLevel === 'research'
               ? 'bg-purple-500/20 text-purple-400 border-purple-500/50'
-              : 'bg-slate-800/50 text-gray-400 border-slate-600/50 hover:border-slate-500'
+              : theme === 'dark' ? 'bg-slate-800/50 text-gray-400 border-slate-600/50 hover:border-slate-500' : 'bg-gray-100/50 text-gray-600 border-gray-300/50 hover:border-gray-400'
           }`}
           whileHover={{ scale: 1.02 }}
           whileTap={{ scale: 0.98 }}
@@ -730,7 +732,7 @@ export function WaveplateDemo() {
           className={`px-6 py-3 rounded-xl text-sm font-medium border-2 transition-all ${
             waveplateType === 'quarter'
               ? 'bg-purple-500/20 text-purple-400 border-purple-400/50'
-              : 'bg-slate-800/50 text-gray-400 border-slate-600/50 hover:border-slate-500'
+              : theme === 'dark' ? 'bg-slate-800/50 text-gray-400 border-slate-600/50 hover:border-slate-500' : 'bg-gray-100/50 text-gray-600 border-gray-300/50 hover:border-gray-400'
           }`}
           whileHover={{ scale: 1.02 }}
           whileTap={{ scale: 0.98 }}
@@ -742,7 +744,7 @@ export function WaveplateDemo() {
           className={`px-6 py-3 rounded-xl text-sm font-medium border-2 transition-all ${
             waveplateType === 'half'
               ? 'bg-pink-500/20 text-pink-400 border-pink-400/50'
-              : 'bg-slate-800/50 text-gray-400 border-slate-600/50 hover:border-slate-500'
+              : theme === 'dark' ? 'bg-slate-800/50 text-gray-400 border-slate-600/50 hover:border-slate-500' : 'bg-gray-100/50 text-gray-600 border-gray-300/50 hover:border-gray-400'
           }`}
           whileHover={{ scale: 1.02 }}
           whileTap={{ scale: 0.98 }}
@@ -753,11 +755,11 @@ export function WaveplateDemo() {
       </div>
 
       {/* 可视化面板 */}
-      <div className="bg-slate-900/50 rounded-xl border border-cyan-400/20 overflow-hidden">
-        <div className="px-4 py-3 border-b border-cyan-400/10 flex items-center justify-between">
-          <h3 className="text-sm font-semibold text-white">光路演示</h3>
+      <div className={`rounded-xl border border-cyan-400/20 overflow-hidden ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-50'}`}>
+        <div className={`px-4 py-3 border-b border-cyan-400/10 flex items-center justify-between`}>
+          <h3 className={`text-sm font-semibold ${theme === 'dark' ? 'text-white' : 'text-gray-900'}`}>光路演示</h3>
           <div className="flex items-center gap-2">
-            <span className="text-xs text-gray-500">快速预设:</span>
+            <span className={`text-xs ${theme === 'dark' ? 'text-gray-500' : 'text-gray-600'}`}>快速预设:</span>
             {presets.map((preset) => (
               <PresetButton
                 key={preset.label}
@@ -811,7 +813,7 @@ export function WaveplateDemo() {
             className={`w-full mt-2 px-4 py-2 rounded-lg text-sm font-medium transition-all ${
               animate
                 ? 'bg-cyan-400/20 text-cyan-400 border border-cyan-400/50'
-                : 'bg-slate-700/50 text-gray-400 border border-slate-600'
+                : theme === 'dark' ? 'bg-slate-700/50 text-gray-400 border border-slate-600' : 'bg-gray-100 text-gray-600 border border-gray-300'
             }`}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
@@ -839,7 +841,7 @@ export function WaveplateDemo() {
         {/* 相位延迟图 */}
         <ControlPanel title="相位延迟示意">
           <PhaseRetardationDiagram waveplateType={waveplateType} />
-          <div className="text-xs text-gray-500 mt-2">
+          <div className={`text-xs mt-2 ${theme === 'dark' ? 'text-gray-500' : 'text-gray-600'}`}>
             {waveplateType === 'quarter'
               ? '快轴与慢轴相位差为 π/2 (90°)'
               : '快轴与慢轴相位差为 π (180°)'}
@@ -850,8 +852,8 @@ export function WaveplateDemo() {
         {difficultyLevel === 'research' && (
           <ControlPanel title="🔬 非理想波片参数">
             {/* 启用非理想模式 */}
-            <div className="flex items-center justify-between py-2 border-b border-slate-700/50">
-              <span className="text-xs text-gray-400">启用非理想模拟</span>
+            <div className={`flex items-center justify-between py-2 border-b ${theme === 'dark' ? 'border-slate-700/50' : 'border-gray-200'}`}>
+              <span className={`text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>启用非理想模拟</span>
               <Toggle
                 label=""
                 checked={nonIdealParams.useNonIdeal}
@@ -930,9 +932,9 @@ export function WaveplateDemo() {
                 />
 
                 {/* 预设按钮 */}
-                <div className="flex gap-2 pt-2 border-t border-slate-700/50">
+                <div className={`flex gap-2 pt-2 border-t ${theme === 'dark' ? 'border-slate-700/50' : 'border-gray-200'}`}>
                   <motion.button
-                    className="flex-1 px-2 py-1.5 text-xs bg-slate-700/50 text-gray-300 rounded hover:bg-slate-600"
+                    className={`flex-1 px-2 py-1.5 text-xs rounded ${theme === 'dark' ? 'bg-slate-700/50 text-gray-300 hover:bg-slate-600' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}`}
                     whileHover={{ scale: 1.02 }}
                     whileTap={{ scale: 0.98 }}
                     onClick={() => setNonIdealParams({ ...IDEAL_WAVEPLATE, useNonIdeal: true })}
@@ -940,7 +942,7 @@ export function WaveplateDemo() {
                     理想波片
                   </motion.button>
                   <motion.button
-                    className="flex-1 px-2 py-1.5 text-xs bg-slate-700/50 text-gray-300 rounded hover:bg-slate-600"
+                    className={`flex-1 px-2 py-1.5 text-xs rounded ${theme === 'dark' ? 'bg-slate-700/50 text-gray-300 hover:bg-slate-600' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}`}
                     whileHover={{ scale: 1.02 }}
                     whileTap={{ scale: 0.98 }}
                     onClick={() => setNonIdealParams({ ...TYPICAL_WAVEPLATE, useNonIdeal: true })}
@@ -953,29 +955,29 @@ export function WaveplateDemo() {
 
             {/* 非理想计算结果 */}
             {nonIdealParams.useNonIdeal && nonIdealResult && (
-              <div className="mt-3 pt-3 border-t border-slate-700/50 space-y-2">
-                <div className="text-xs text-gray-500 font-medium">非理想计算结果</div>
+              <div className={`mt-3 pt-3 border-t space-y-2 ${theme === 'dark' ? 'border-slate-700/50' : 'border-gray-200'}`}>
+                <div className={`text-xs font-medium ${theme === 'dark' ? 'text-gray-500' : 'text-gray-600'}`}>非理想计算结果</div>
                 <div className="grid grid-cols-2 gap-2 text-xs">
-                  <div className="p-2 bg-slate-900/50 rounded">
-                    <div className="text-gray-500">实际相位延迟</div>
+                  <div className={`p-2 rounded ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'}`}>
+                    <div className={theme === 'dark' ? 'text-gray-500' : 'text-gray-600'}>实际相位延迟</div>
                     <div className="text-purple-400 font-mono">
                       {(nonIdealResult.actualRetardation * 180 / Math.PI).toFixed(2)}°
                     </div>
                   </div>
-                  <div className="p-2 bg-slate-900/50 rounded">
-                    <div className="text-gray-500">输出强度</div>
+                  <div className={`p-2 rounded ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'}`}>
+                    <div className={theme === 'dark' ? 'text-gray-500' : 'text-gray-600'}>输出强度</div>
                     <div className="text-green-400 font-mono">
                       {(nonIdealResult.outputIntensity * 100).toFixed(1)}%
                     </div>
                   </div>
-                  <div className="p-2 bg-slate-900/50 rounded">
-                    <div className="text-gray-500">椭圆度</div>
+                  <div className={`p-2 rounded ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'}`}>
+                    <div className={theme === 'dark' ? 'text-gray-500' : 'text-gray-600'}>椭圆度</div>
                     <div className="text-cyan-400 font-mono">
                       {(nonIdealResult.ellipticity * 100).toFixed(1)}%
                     </div>
                   </div>
-                  <div className="p-2 bg-slate-900/50 rounded">
-                    <div className="text-gray-500">偏振度(DOP)</div>
+                  <div className={`p-2 rounded ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'}`}>
+                    <div className={theme === 'dark' ? 'text-gray-500' : 'text-gray-600'}>偏振度(DOP)</div>
                     <div className="text-orange-400 font-mono">
                       {(nonIdealResult.outputStokes.degreeOfPolarization * 100).toFixed(1)}%
                     </div>
@@ -999,18 +1001,18 @@ export function WaveplateDemo() {
 
       {/* 波片功能说明 */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div className={`p-4 rounded-xl border ${waveplateType === 'quarter' ? 'bg-purple-500/10 border-purple-400/30' : 'bg-slate-800/50 border-slate-700/50'}`}>
+        <div className={`p-4 rounded-xl border ${waveplateType === 'quarter' ? 'bg-purple-500/10 border-purple-400/30' : theme === 'dark' ? 'bg-slate-800/50 border-slate-700/50' : 'bg-gray-100/50 border-gray-200'}`}>
           <h4 className="font-semibold text-purple-400 mb-2">λ/4 四分之一波片</h4>
-          <ul className="text-xs text-gray-300 space-y-1">
+          <ul className={`text-xs space-y-1 ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}`}>
             <li>• 相位延迟: π/2 (90°)</li>
             <li>• 45°线偏振 → 圆偏振</li>
             <li>• 0°/90°线偏振 → 保持不变</li>
             <li>• 其他角度 → 椭圆偏振</li>
           </ul>
         </div>
-        <div className={`p-4 rounded-xl border ${waveplateType === 'half' ? 'bg-pink-500/10 border-pink-400/30' : 'bg-slate-800/50 border-slate-700/50'}`}>
+        <div className={`p-4 rounded-xl border ${waveplateType === 'half' ? 'bg-pink-500/10 border-pink-400/30' : theme === 'dark' ? 'bg-slate-800/50 border-slate-700/50' : 'bg-gray-100/50 border-gray-200'}`}>
           <h4 className="font-semibold text-pink-400 mb-2">λ/2 二分之一波片</h4>
-          <ul className="text-xs text-gray-300 space-y-1">
+          <ul className={`text-xs space-y-1 ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}`}>
             <li>• 相位延迟: π (180°)</li>
             <li>• 线偏振方向旋转</li>
             <li>• 旋转角度 = 2 × 快轴角度</li>

--- a/src/components/demos/unit2/BrewsterDemo.tsx
+++ b/src/components/demos/unit2/BrewsterDemo.tsx
@@ -12,6 +12,7 @@ import { useState, useMemo } from 'react'
 import { motion } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
 import { SliderControl, ControlPanel, InfoCard, Toggle } from '../DemoControls'
+import { useTheme } from '@/contexts/ThemeContext'
 import {
   sellmeierIndex,
   cauchyIndex,
@@ -720,6 +721,7 @@ function PolarizationDegreeChart({
 
 // 主演示组件
 export function BrewsterDemo() {
+  const { theme } = useTheme()
   const { t } = useTranslation()
   const [incidentAngle, setIncidentAngle] = useState(56)
   const [wavelength, setWavelength] = useState(550) // 绿光默认
@@ -769,10 +771,10 @@ export function BrewsterDemo() {
     <div className="space-y-6">
       {/* 标题 */}
       <div className="text-center">
-        <h2 className="text-2xl font-bold bg-gradient-to-r from-white via-cyan-100 to-white bg-clip-text text-transparent">
+        <h2 className={`text-2xl font-bold bg-gradient-to-r bg-clip-text text-transparent ${theme === 'dark' ? 'from-white via-cyan-100 to-white' : 'from-gray-800 via-cyan-600 to-gray-800'}`}>
           {t('demoUi.brewster.title')}
         </h2>
-        <p className="text-gray-400 mt-1">
+        <p className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>
           {t('demoUi.brewster.subtitle')}
         </p>
       </div>
@@ -781,36 +783,36 @@ export function BrewsterDemo() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* 左侧：可视化 */}
         <div className="space-y-4">
-          <div className="rounded-xl bg-gradient-to-br from-slate-900/90 via-slate-900/95 to-cyan-950/90 border border-cyan-500/30 p-4 shadow-[0_15px_40px_rgba(0,0,0,0.5)]">
+          <div className={`rounded-xl border p-4 ${theme === 'dark' ? 'bg-gradient-to-br from-slate-900/90 via-slate-900/95 to-cyan-950/90 border-cyan-500/30 shadow-[0_15px_40px_rgba(0,0,0,0.5)]' : 'bg-gradient-to-br from-white via-gray-50 to-cyan-50 border-cyan-200 shadow-lg'}`}>
             <BrewsterDiagram incidentAngle={incidentAngle} n1={n1} n2={n2} labels={diagramLabels} />
           </div>
 
           {/* 状态指示 */}
-          <div className="rounded-xl bg-gradient-to-br from-slate-900/80 to-slate-800/80 border border-slate-600/30 p-4">
+          <div className={`rounded-xl border p-4 ${theme === 'dark' ? 'bg-gradient-to-br from-slate-900/80 to-slate-800/80 border-slate-600/30' : 'bg-gradient-to-br from-gray-50 to-white border-gray-200 shadow-sm'}`}>
             <div className="flex items-center justify-between">
               <div className="space-y-2">
                 <div className="flex items-center gap-3">
-                  <span className="text-sm text-gray-400">{t('demoUi.brewster.currentIncidentAngle')}</span>
-                  <span className="font-mono text-lg text-orange-400">{incidentAngle}°</span>
+                  <span className={`text-sm ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>{t('demoUi.brewster.currentIncidentAngle')}</span>
+                  <span className="font-mono text-lg text-orange-500">{incidentAngle}°</span>
                 </div>
                 <div className="flex items-center gap-3">
-                  <span className="text-sm text-gray-400">{t('demoUi.brewster.brewsterAngle')}</span>
-                  <span className="font-mono text-lg text-cyan-400">{brewsterAngle.toFixed(1)}°</span>
+                  <span className={`text-sm ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>{t('demoUi.brewster.brewsterAngle')}</span>
+                  <span className="font-mono text-lg text-cyan-500">{brewsterAngle.toFixed(1)}°</span>
                 </div>
               </div>
               <div className="text-right">
-                <div className={`text-2xl font-bold ${isAtBrewster ? 'text-green-400' : 'text-gray-500'}`}>
+                <div className={`text-2xl font-bold ${isAtBrewster ? 'text-green-500' : 'text-gray-500'}`}>
                   {isAtBrewster ? t('demoUi.brewster.match') : `${t('demoUi.brewster.difference')} ${Math.abs(incidentAngle - brewsterAngle).toFixed(1)}°`}
                 </div>
                 <div className="text-sm text-gray-500">
-                  {t('demoUi.brewster.polarizationDegree')} <span className="text-purple-400 font-mono">{(polarizationDegree * 100).toFixed(0)}%</span>
+                  {t('demoUi.brewster.polarizationDegree')} <span className="text-purple-500 font-mono">{(polarizationDegree * 100).toFixed(0)}%</span>
                 </div>
               </div>
             </div>
 
             {/* 进度条 */}
             <div className="mt-4">
-              <div className="h-2 bg-slate-700 rounded-full overflow-hidden">
+              <div className={`h-2 rounded-full overflow-hidden ${theme === 'dark' ? 'bg-slate-700' : 'bg-gray-200'}`}>
                 <motion.div
                   className="h-full rounded-full"
                   style={{
@@ -842,8 +844,8 @@ export function BrewsterDemo() {
             />
 
             {/* 色散模式开关 */}
-            <div className="flex items-center justify-between py-2 border-t border-slate-700/50">
-              <span className="text-xs text-gray-400">{t('demoUi.brewster.dispersionMode')}</span>
+            <div className={`flex items-center justify-between py-2 border-t ${theme === 'dark' ? 'border-slate-700/50' : 'border-gray-200'}`}>
+              <span className={`text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>{t('demoUi.brewster.dispersionMode')}</span>
               <Toggle
                 label=""
                 checked={showDispersion}
@@ -876,7 +878,7 @@ export function BrewsterDemo() {
             )}
 
             {/* 材料选择器 */}
-            <div className="pt-2 border-t border-slate-700/50">
+            <div className={`pt-2 border-t ${theme === 'dark' ? 'border-slate-700/50' : 'border-gray-200'}`}>
               <div className="text-xs text-gray-500 mb-2">{t('demoUi.brewster.selectMaterial')}</div>
               <div className="grid grid-cols-2 gap-1.5">
                 {DISPERSIVE_MATERIALS.map((m, index) => {
@@ -893,7 +895,9 @@ export function BrewsterDemo() {
                       className={`px-2 py-1.5 text-xs rounded transition-all ${
                         isSelected
                           ? 'bg-cyan-500/30 text-cyan-300 border border-cyan-500/50'
-                          : 'bg-slate-700/50 text-gray-400 border border-transparent hover:bg-slate-600'
+                          : theme === 'dark'
+                            ? 'bg-slate-700/50 text-gray-400 border border-transparent hover:bg-slate-600'
+                            : 'bg-gray-100 text-gray-600 border border-transparent hover:bg-gray-200'
                       }`}
                     >
                       {t(m.nameKey).replace('demoUi.brewster.', '')}
@@ -904,15 +908,15 @@ export function BrewsterDemo() {
             </div>
 
             {/* 显示当前折射率 */}
-            <div className="mt-2 p-2 bg-slate-900/50 rounded-lg">
+            <div className={`mt-2 p-2 rounded-lg ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'}`}>
               <div className="flex justify-between text-xs">
                 <span className="text-gray-500">n({wavelength}nm)</span>
-                <span className="text-cyan-400 font-mono">{n2.toFixed(4)}</span>
+                <span className="text-cyan-500 font-mono">{n2.toFixed(4)}</span>
               </div>
               {showDispersion && (
                 <div className="flex justify-between text-xs mt-1">
                   <span className="text-gray-500">{t('demoUi.brewster.dispersionRange')}</span>
-                  <span className="text-purple-400 font-mono">{dispersionRange.toFixed(2)}°</span>
+                  <span className="text-purple-500 font-mono">{dispersionRange.toFixed(2)}°</span>
                 </div>
               )}
             </div>
@@ -931,31 +935,31 @@ export function BrewsterDemo() {
           {/* 计算结果 */}
           <ControlPanel title={t('demoUi.common.calculationResult')}>
             <div className="grid grid-cols-2 gap-3 text-sm">
-              <div className="p-2 bg-slate-900/50 rounded-lg">
+              <div className={`p-2 rounded-lg ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'}`}>
                 <div className="text-gray-500 text-xs">{t('demoUi.brewster.sPolReflectance')}</div>
-                <div className="text-cyan-400 font-mono text-lg">{(result.Rs * 100).toFixed(1)}%</div>
+                <div className="text-cyan-500 font-mono text-lg">{(result.Rs * 100).toFixed(1)}%</div>
               </div>
-              <div className="p-2 bg-slate-900/50 rounded-lg">
+              <div className={`p-2 rounded-lg ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'}`}>
                 <div className="text-gray-500 text-xs">{t('demoUi.brewster.pPolReflectance')}</div>
-                <div className={`font-mono text-lg ${result.Rp < 0.01 ? 'text-green-400' : 'text-pink-400'}`}>
+                <div className={`font-mono text-lg ${result.Rp < 0.01 ? 'text-green-500' : 'text-pink-500'}`}>
                   {(result.Rp * 100).toFixed(1)}%
                 </div>
               </div>
-              <div className="p-2 bg-slate-900/50 rounded-lg">
+              <div className={`p-2 rounded-lg ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'}`}>
                 <div className="text-gray-500 text-xs">{t('demoUi.brewster.refractionAngle')}</div>
-                <div className="text-green-400 font-mono text-lg">{result.theta2.toFixed(1)}°</div>
+                <div className="text-green-500 font-mono text-lg">{result.theta2.toFixed(1)}°</div>
               </div>
-              <div className="p-2 bg-slate-900/50 rounded-lg">
+              <div className={`p-2 rounded-lg ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'}`}>
                 <div className="text-gray-500 text-xs">θ₁ + θ₂</div>
-                <div className={`font-mono text-lg ${Math.abs(incidentAngle + result.theta2 - 90) < 1.5 ? 'text-green-400' : 'text-gray-400'}`}>
+                <div className={`font-mono text-lg ${Math.abs(incidentAngle + result.theta2 - 90) < 1.5 ? 'text-green-500' : 'text-gray-400'}`}>
                   {(incidentAngle + result.theta2).toFixed(1)}°
                 </div>
               </div>
             </div>
 
             {/* 公式 */}
-            <div className="mt-3 p-3 bg-slate-900/50 rounded-lg text-center">
-              <span className="font-mono text-lg bg-gradient-to-r from-cyan-400 to-white bg-clip-text text-transparent">
+            <div className={`mt-3 p-3 rounded-lg text-center ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'}`}>
+              <span className={`font-mono text-lg bg-gradient-to-r bg-clip-text text-transparent ${theme === 'dark' ? 'from-cyan-400 to-white' : 'from-cyan-600 to-gray-800'}`}>
                 tan(θB) = n₂/n₁ = {n2.toFixed(2)}/{n1.toFixed(2)} = {(n2/n1).toFixed(3)}
               </span>
             </div>
@@ -964,7 +968,7 @@ export function BrewsterDemo() {
           {/* 偏振度曲线 */}
           <ControlPanel title={t('demoUi.brewster.reflectedPolDegree')}>
             <PolarizationDegreeChart n1={n1} n2={n2} currentAngle={incidentAngle} />
-            <p className="text-xs text-gray-400 mt-2">
+            <p className={`text-xs mt-2 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
               {t('demoUi.brewster.chartDesc')}
             </p>
           </ControlPanel>

--- a/src/components/demos/unit2/FresnelDemo.tsx
+++ b/src/components/demos/unit2/FresnelDemo.tsx
@@ -6,6 +6,7 @@
 import { useState, useMemo } from 'react'
 import { motion } from 'framer-motion'
 import { SliderControl, ControlPanel, InfoCard } from '../DemoControls'
+import { useTheme } from '@/contexts/ThemeContext'
 
 // 菲涅尔方程计算
 function fresnelEquations(theta1: number, n1: number, n2: number) {
@@ -572,6 +573,7 @@ function FresnelCurveChart({
 
 // 主演示组件
 export function FresnelDemo() {
+  const { theme } = useTheme()
   const [incidentAngle, setIncidentAngle] = useState(45)
   const [n1, setN1] = useState(1.0)
   const [n2, setN2] = useState(1.5)
@@ -612,10 +614,10 @@ export function FresnelDemo() {
     <div className="space-y-6">
       {/* 标题 */}
       <div className="text-center">
-        <h2 className="text-2xl font-bold bg-gradient-to-r from-white via-cyan-100 to-white bg-clip-text text-transparent">
+        <h2 className={`text-2xl font-bold bg-gradient-to-r bg-clip-text text-transparent ${theme === 'dark' ? 'from-white via-cyan-100 to-white' : 'from-gray-800 via-cyan-600 to-gray-800'}`}>
           菲涅尔方程交互演示
         </h2>
-        <p className="text-gray-400 mt-1">
+        <p className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>
           探索s偏振和p偏振光在界面反射/折射时的行为差异
         </p>
       </div>
@@ -625,7 +627,7 @@ export function FresnelDemo() {
         {/* 左侧：可视化 */}
         <div className="space-y-4">
           {/* 光线图 */}
-          <div className="rounded-xl bg-gradient-to-br from-slate-900/90 via-slate-900/95 to-cyan-950/90 border border-cyan-500/30 p-4 shadow-[0_15px_40px_rgba(0,0,0,0.5)]">
+          <div className={`rounded-xl border p-4 ${theme === 'dark' ? 'bg-gradient-to-br from-slate-900/90 via-slate-900/95 to-cyan-950/90 border-cyan-500/30 shadow-[0_15px_40px_rgba(0,0,0,0.5)]' : 'bg-gradient-to-br from-white via-gray-50 to-cyan-50 border-cyan-200 shadow-lg'}`}>
             <FresnelDiagram
               incidentAngle={incidentAngle}
               n1={n1}
@@ -636,8 +638,8 @@ export function FresnelDemo() {
           </div>
 
           {/* 反射率/透射率条 */}
-          <div className="rounded-xl bg-gradient-to-br from-slate-900/80 to-slate-800/80 border border-slate-600/30 p-4 space-y-3">
-            <h4 className="text-sm font-semibold text-white mb-3">反射率与透射率</h4>
+          <div className={`rounded-xl border p-4 space-y-3 ${theme === 'dark' ? 'bg-gradient-to-br from-slate-900/80 to-slate-800/80 border-slate-600/30' : 'bg-gradient-to-br from-gray-50 to-white border-gray-200 shadow-sm'}`}>
+            <h4 className={`text-sm font-semibold mb-3 ${theme === 'dark' ? 'text-white' : 'text-gray-800'}`}>反射率与透射率</h4>
             {showS && (
               <>
                 <IntensityBar label="Rs (s偏振反射率)" value={Rs} color="cyan" />
@@ -690,23 +692,23 @@ export function FresnelDemo() {
 
             {/* 偏振选择 */}
             <div className="flex gap-4 pt-2">
-              <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer">
+              <label className={`flex items-center gap-2 text-sm cursor-pointer ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
                 <input
                   type="checkbox"
                   checked={showS}
                   onChange={(e) => setShowS(e.target.checked)}
                   className="rounded border-cyan-500 text-cyan-500 focus:ring-cyan-500"
                 />
-                <span className="text-cyan-400">s偏振</span>
+                <span className="text-cyan-500">s偏振</span>
               </label>
-              <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer">
+              <label className={`flex items-center gap-2 text-sm cursor-pointer ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
                 <input
                   type="checkbox"
                   checked={showP}
                   onChange={(e) => setShowP(e.target.checked)}
                   className="rounded border-pink-500 text-pink-500 focus:ring-pink-500"
                 />
-                <span className="text-pink-400">p偏振</span>
+                <span className="text-pink-500">p偏振</span>
               </label>
             </div>
 
@@ -718,7 +720,7 @@ export function FresnelDemo() {
                   <button
                     key={m.name}
                     onClick={() => { setN1(m.n1); setN2(m.n2) }}
-                    className="px-2 py-1.5 text-xs bg-slate-700/50 text-gray-300 rounded hover:bg-slate-600 transition-colors"
+                    className={`px-2 py-1.5 text-xs rounded transition-colors ${theme === 'dark' ? 'bg-slate-700/50 text-gray-300 hover:bg-slate-600' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}
                   >
                     {m.name}
                   </button>
@@ -730,29 +732,29 @@ export function FresnelDemo() {
           {/* 计算结果 */}
           <ControlPanel title="计算结果">
             <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-              <div className="text-gray-400">
-                折射角 θ₂ = <span className="text-green-400 font-mono">
+              <div className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>
+                折射角 θ₂ = <span className="text-green-500 font-mono">
                   {fresnel.totalReflection ? '全反射' : `${fresnel.theta2.toFixed(1)}°`}
                 </span>
               </div>
-              <div className="text-gray-400">
-                布儒斯特角 = <span className="text-yellow-400 font-mono">{brewsterAngle.toFixed(1)}°</span>
+              <div className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>
+                布儒斯特角 = <span className="text-yellow-500 font-mono">{brewsterAngle.toFixed(1)}°</span>
               </div>
               {criticalAngle && (
-                <div className="col-span-2 text-gray-400">
-                  临界角 = <span className="text-red-400 font-mono">{criticalAngle.toFixed(1)}°</span>
+                <div className={`col-span-2 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
+                  临界角 = <span className="text-red-500 font-mono">{criticalAngle.toFixed(1)}°</span>
                   <span className="text-gray-500 text-xs ml-2">(全内反射)</span>
                 </div>
               )}
             </div>
 
             {/* 公式显示 */}
-            <div className="mt-3 p-3 bg-slate-900/50 rounded-lg">
+            <div className={`mt-3 p-3 rounded-lg ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'}`}>
               <div className="text-xs text-gray-500 mb-2">菲涅尔方程</div>
-              <div className="font-mono text-xs text-gray-300 space-y-1">
+              <div className={`font-mono text-xs space-y-1 ${theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}`}>
                 <p>rs = (n₁cosθ₁ - n₂cosθ₂) / (n₁cosθ₁ + n₂cosθ₂)</p>
                 <p>rp = (n₂cosθ₁ - n₁cosθ₂) / (n₂cosθ₁ + n₁cosθ₂)</p>
-                <p className="text-cyan-400 pt-1">Rs = rs², Rp = rp²</p>
+                <p className="text-cyan-500 pt-1">Rs = rs², Rp = rp²</p>
               </div>
             </div>
           </ControlPanel>
@@ -760,7 +762,7 @@ export function FresnelDemo() {
           {/* 反射率曲线 */}
           <ControlPanel title="反射率曲线 R(θ)">
             <FresnelCurveChart n1={n1} n2={n2} currentAngle={incidentAngle} />
-            <p className="text-xs text-gray-400 mt-2">
+            <p className={`text-xs mt-2 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
               红点表示当前入射角对应的反射率。在布儒斯特角处，p偏振反射率为零。
             </p>
           </ControlPanel>

--- a/src/components/demos/unit3/ChromaticDemo.tsx
+++ b/src/components/demos/unit3/ChromaticDemo.tsx
@@ -8,6 +8,7 @@ import { motion } from 'framer-motion'
 import { SliderControl, ControlPanel, InfoCard } from '../DemoControls'
 import { MediaGalleryPanel } from './MediaGalleryPanel'
 import { RealExperimentMicroGallery } from '@/components/real-experiments'
+import { useTheme } from '@/contexts/ThemeContext'
 
 // 波长到RGB颜色转换
 function wavelengthToRGB(wavelength: number): [number, number, number] {
@@ -491,6 +492,7 @@ function ColorDisplayPanel({
 
 // 主演示组件
 export function ChromaticDemo() {
+  const { theme } = useTheme()
   // 默认值设置为能显示明显干涉色的参数
   // OPD = 0.05mm × 0.04 × 1000 = 2000nm ≈ 3.6λ (云母)
   const [thickness, setThickness] = useState(0.05)
@@ -518,10 +520,10 @@ export function ChromaticDemo() {
     <div className="space-y-6">
       {/* 页面标题 */}
       <div className="text-center">
-        <h2 className="text-2xl font-bold bg-gradient-to-r from-white via-purple-100 to-white bg-clip-text text-transparent">
+        <h2 className={`text-2xl font-bold bg-gradient-to-r bg-clip-text text-transparent ${theme === 'dark' ? 'from-white via-purple-100 to-white' : 'from-gray-800 via-purple-600 to-gray-800'}`}>
           光学各向异性 - 色偏振
         </h2>
-        <p className="text-gray-400 mt-1">
+        <p className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>
           探索双折射材料产生的彩色干涉效应
         </p>
       </div>
@@ -531,14 +533,14 @@ export function ChromaticDemo() {
 
       {/* 交互演示区域标题 */}
       <div className="flex items-center gap-3 pt-2">
-        <div className="h-px flex-1 bg-gradient-to-r from-transparent via-purple-500/30 to-transparent" />
-        <h3 className="text-lg font-semibold text-purple-300 flex items-center gap-2">
+        <div className={`h-px flex-1 bg-gradient-to-r from-transparent to-transparent ${theme === 'dark' ? 'via-purple-500/30' : 'via-purple-300/50'}`} />
+        <h3 className={`text-lg font-semibold flex items-center gap-2 ${theme === 'dark' ? 'text-purple-300' : 'text-purple-600'}`}>
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122" />
           </svg>
           交互演示
         </h3>
-        <div className="h-px flex-1 bg-gradient-to-r from-transparent via-purple-500/30 to-transparent" />
+        <div className={`h-px flex-1 bg-gradient-to-r from-transparent to-transparent ${theme === 'dark' ? 'via-purple-500/30' : 'via-purple-300/50'}`} />
       </div>
 
       {/* 主体内容 */}
@@ -546,7 +548,7 @@ export function ChromaticDemo() {
         {/* 左侧：可视化 */}
         <div className="space-y-4">
           {/* 光路图 */}
-          <div className="rounded-xl bg-gradient-to-br from-slate-900/90 via-slate-900/95 to-purple-950/90 border border-purple-500/30 p-4 shadow-[0_15px_40px_rgba(0,0,0,0.5)]">
+          <div className={`rounded-xl border p-4 ${theme === 'dark' ? 'bg-gradient-to-br from-slate-900/90 via-slate-900/95 to-purple-950/90 border-purple-500/30 shadow-[0_15px_40px_rgba(0,0,0,0.5)]' : 'bg-gradient-to-br from-white via-gray-50 to-purple-50 border-purple-200 shadow-lg'}`}>
             <OpticalPathDiagram
               thickness={thickness}
               birefringence={birefringence}
@@ -557,8 +559,8 @@ export function ChromaticDemo() {
           </div>
 
           {/* 观察到的颜色 */}
-          <div className="rounded-xl bg-gradient-to-br from-slate-900/80 to-slate-800/80 border border-slate-600/30 p-4">
-            <h4 className="text-sm font-semibold text-white mb-3">观察到的颜色</h4>
+          <div className={`rounded-xl border p-4 ${theme === 'dark' ? 'bg-gradient-to-br from-slate-900/80 to-slate-800/80 border-slate-600/30' : 'bg-gradient-to-br from-gray-50 to-white border-gray-200 shadow-sm'}`}>
+            <h4 className={`text-sm font-semibold mb-3 ${theme === 'dark' ? 'text-white' : 'text-gray-800'}`}>观察到的颜色</h4>
             <ColorDisplayPanel color={resultColor} />
           </div>
         </div>
@@ -599,7 +601,9 @@ export function ChromaticDemo() {
                     className={`px-2 py-1.5 text-xs rounded transition-colors ${
                       Math.abs(birefringence - m.br) < 0.0001
                         ? 'bg-purple-500/30 text-purple-300 border border-purple-500/50'
-                        : 'bg-slate-700/50 text-gray-300 hover:bg-slate-600'
+                        : theme === 'dark'
+                          ? 'bg-slate-700/50 text-gray-300 hover:bg-slate-600'
+                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                     }`}
                   >
                     {m.name}
@@ -634,7 +638,7 @@ export function ChromaticDemo() {
 
             <div className="flex gap-2 pt-2">
               <motion.button
-                className="flex-1 py-1.5 text-xs bg-slate-700/50 text-gray-300 rounded hover:bg-slate-600 transition-colors"
+                className={`flex-1 py-1.5 text-xs rounded transition-colors ${theme === 'dark' ? 'bg-slate-700/50 text-gray-300 hover:bg-slate-600' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
                 onClick={() => setAnalyzerAngle(polarizerAngle)}
@@ -642,7 +646,7 @@ export function ChromaticDemo() {
                 平行设置
               </motion.button>
               <motion.button
-                className="flex-1 py-1.5 text-xs bg-slate-700/50 text-gray-300 rounded hover:bg-slate-600 transition-colors"
+                className={`flex-1 py-1.5 text-xs rounded transition-colors ${theme === 'dark' ? 'bg-slate-700/50 text-gray-300 hover:bg-slate-600' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
                 onClick={() => setAnalyzerAngle((polarizerAngle + 90) % 180)}
@@ -655,17 +659,17 @@ export function ChromaticDemo() {
           {/* 相位延迟信息 */}
           <ControlPanel title="相位延迟">
             <div className="grid grid-cols-2 gap-3 text-sm">
-              <div className="p-2 bg-slate-900/50 rounded-lg">
+              <div className={`p-2 rounded-lg ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'}`}>
                 <div className="text-gray-500 text-xs">光程差 Δn×d</div>
-                <div className="text-cyan-400 font-mono">{opticalPathDiff.toFixed(1)} nm</div>
+                <div className="text-cyan-500 font-mono">{opticalPathDiff.toFixed(1)} nm</div>
               </div>
-              <div className="p-2 bg-slate-900/50 rounded-lg">
+              <div className={`p-2 rounded-lg ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'}`}>
                 <div className="text-gray-500 text-xs">相位延迟 (550nm)</div>
-                <div className="text-purple-400 font-mono">{(phaseRetardation * 180 / Math.PI).toFixed(0)}°</div>
+                <div className="text-purple-500 font-mono">{(phaseRetardation * 180 / Math.PI).toFixed(0)}°</div>
               </div>
-              <div className="p-2 bg-slate-900/50 rounded-lg col-span-2">
+              <div className={`p-2 rounded-lg col-span-2 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'}`}>
                 <div className="text-gray-500 text-xs">延迟级次</div>
-                <div className="text-orange-400 font-mono">{retardationOrders.toFixed(2)} λ</div>
+                <div className="text-orange-500 font-mono">{retardationOrders.toFixed(2)} λ</div>
               </div>
             </div>
           </ControlPanel>
@@ -678,7 +682,7 @@ export function ChromaticDemo() {
               polarizerAngle={polarizerAngle}
               analyzerAngle={analyzerAngle}
             />
-            <p className="text-xs text-gray-400 mt-2">
+            <p className={`text-xs mt-2 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
               不同波长的透过率不同，导致出射光呈现特定颜色。
             </p>
           </ControlPanel>

--- a/src/components/demos/unit3/MediaGalleryPanel.tsx
+++ b/src/components/demos/unit3/MediaGalleryPanel.tsx
@@ -22,6 +22,7 @@ import {
   Camera,
   Film
 } from 'lucide-react'
+import { useTheme } from '@/contexts/ThemeContext'
 import {
   CULTURAL_MEDIA,
   CULTURAL_SERIES,
@@ -105,6 +106,7 @@ function MediaThumbnail({
   isVideo?: boolean
   size?: 'sm' | 'md' | 'lg' | 'xl'
 }) {
+  const { theme } = useTheme()
   const { i18n } = useTranslation()
   const isZh = i18n.language === 'zh'
   const sizeClasses = {
@@ -116,8 +118,8 @@ function MediaThumbnail({
 
   return (
     <motion.button
-      className={`${sizeClasses[size]} relative rounded-lg overflow-hidden border border-slate-600/50
-        hover:border-purple-500/50 transition-all group cursor-pointer`}
+      className={`${sizeClasses[size]} relative rounded-lg overflow-hidden border
+        hover:border-purple-500/50 transition-all group cursor-pointer ${theme === 'dark' ? 'border-slate-600/50' : 'border-gray-200'}`}
       whileHover={{ scale: 1.05 }}
       whileTap={{ scale: 0.95 }}
       onClick={onClick}
@@ -374,12 +376,14 @@ function CategoryTab({
   active,
   onClick,
   count,
+  theme,
 }: {
   icon: ComponentType<{ className?: string }>
   label: string
   active: boolean
   onClick: () => void
   count: number
+  theme: 'light' | 'dark'
 }) {
   return (
     <button
@@ -387,7 +391,9 @@ function CategoryTab({
       className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-all ${
         active
           ? 'bg-purple-500/30 text-purple-300 border border-purple-500/50'
-          : 'bg-slate-700/50 text-gray-400 hover:text-gray-300 hover:bg-slate-600/50'
+          : theme === 'dark'
+            ? 'bg-slate-700/50 text-gray-400 hover:text-gray-300 hover:bg-slate-600/50'
+            : 'bg-gray-100 text-gray-600 hover:text-gray-700 hover:bg-gray-200'
       }`}
     >
       <Icon className="w-3.5 h-3.5" />
@@ -401,17 +407,19 @@ function CategoryTab({
 function SeriesLinkCard({
   series,
   isZh,
+  theme,
 }: {
   series: CulturalSeries
   isZh: boolean
+  theme: 'light' | 'dark'
 }) {
   return (
     <Link
       to={`/experiments/showcase`}
-      className="group flex items-center gap-3 p-2.5 rounded-lg bg-slate-800/50 border border-slate-700/50
-        hover:border-pink-500/50 hover:bg-slate-800 transition-all"
+      className={`group flex items-center gap-3 p-2.5 rounded-lg border
+        hover:border-pink-500/50 transition-all ${theme === 'dark' ? 'bg-slate-800/50 border-slate-700/50 hover:bg-slate-800' : 'bg-gray-50 border-gray-200 hover:bg-gray-100'}`}
     >
-      <div className="w-12 h-12 rounded-lg overflow-hidden flex-shrink-0 bg-slate-900">
+      <div className={`w-12 h-12 rounded-lg overflow-hidden flex-shrink-0 ${theme === 'dark' ? 'bg-slate-900' : 'bg-gray-200'}`}>
         <img
           src={series.thumbnail}
           alt={isZh ? series.nameZh : series.name}
@@ -420,7 +428,7 @@ function SeriesLinkCard({
         />
       </div>
       <div className="flex-1 min-w-0">
-        <h4 className="text-xs font-medium text-white truncate group-hover:text-pink-300 transition-colors">
+        <h4 className={`text-xs font-medium truncate group-hover:text-pink-500 transition-colors ${theme === 'dark' ? 'text-white' : 'text-gray-800'}`}>
           {isZh ? series.nameZh : series.name}
         </h4>
         <p className="text-[10px] text-gray-500 truncate">
@@ -434,6 +442,7 @@ function SeriesLinkCard({
 
 // 主组件
 export function MediaGalleryPanel() {
+  const { theme } = useTheme()
   const { i18n } = useTranslation()
   const isZh = i18n.language === 'zh'
 
@@ -494,16 +503,15 @@ export function MediaGalleryPanel() {
   }
 
   return (
-    <div className="rounded-xl bg-gradient-to-br from-slate-900/80 to-purple-950/30
-      border border-purple-500/20 overflow-hidden">
+    <div className={`rounded-xl border overflow-hidden ${theme === 'dark' ? 'bg-gradient-to-br from-slate-900/80 to-purple-950/30 border-purple-500/20' : 'bg-gradient-to-br from-white to-purple-50/30 border-purple-200'}`}>
       {/* 头部 - 可点击展开/折叠 */}
       <button
         onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-center justify-between p-4 hover:bg-white/5 transition-colors"
+        className={`w-full flex items-center justify-between p-4 transition-colors ${theme === 'dark' ? 'hover:bg-white/5' : 'hover:bg-purple-50'}`}
       >
         <div className="flex items-center gap-2">
-          <Camera className="w-5 h-5 text-purple-400" />
-          <h3 className="text-sm font-semibold text-white">
+          <Camera className={`w-5 h-5 ${theme === 'dark' ? 'text-purple-400' : 'text-purple-500'}`} />
+          <h3 className={`text-sm font-semibold ${theme === 'dark' ? 'text-white' : 'text-gray-800'}`}>
             {isZh ? '真实实验场景' : 'Real Experiment Scenes'}
           </h3>
           <span className="text-xs text-gray-500">
@@ -522,10 +530,10 @@ export function MediaGalleryPanel() {
       {!isExpanded && (
         <div className="px-4 pb-4 space-y-4">
           {/* 内容说明 */}
-          <div className="flex items-start gap-3 p-3 rounded-lg bg-slate-800/30 border border-slate-700/30">
-            <Film className="w-4 h-4 text-purple-400 flex-shrink-0 mt-0.5" />
+          <div className={`flex items-start gap-3 p-3 rounded-lg border ${theme === 'dark' ? 'bg-slate-800/30 border-slate-700/30' : 'bg-gray-50 border-gray-200'}`}>
+            <Film className={`w-4 h-4 flex-shrink-0 mt-0.5 ${theme === 'dark' ? 'text-purple-400' : 'text-purple-500'}`} />
             <div className="flex-1 min-w-0">
-              <p className="text-xs text-gray-300 leading-relaxed">
+              <p className={`text-xs leading-relaxed ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
                 {isZh
                   ? '包含实验室拍摄的色偏振照片和视频：应力双折射、保鲜膜干涉、透明胶带效果等真实实验记录，以及偏振艺术文创作品展示。'
                   : 'Contains lab-captured chromatic polarization photos and videos: stress birefringence, plastic wrap interference, tape effects, and polarization art creations.'}
@@ -559,9 +567,9 @@ export function MediaGalleryPanel() {
                 />
               ))}
               <motion.button
-                className="w-28 h-28 flex-shrink-0 rounded-lg border border-dashed border-slate-600
+                className={`w-28 h-28 flex-shrink-0 rounded-lg border border-dashed
                   flex flex-col items-center justify-center text-gray-500 hover:text-gray-400
-                  hover:border-purple-500/50 hover:bg-purple-500/5 transition-colors gap-1"
+                  hover:border-purple-500/50 hover:bg-purple-500/5 transition-colors gap-1 ${theme === 'dark' ? 'border-slate-600' : 'border-gray-300'}`}
                 whileHover={{ scale: 1.02 }}
                 onClick={() => setIsExpanded(true)}
               >
@@ -591,6 +599,7 @@ export function MediaGalleryPanel() {
                   key={series.id}
                   series={series}
                   isZh={isZh}
+                  theme={theme}
                 />
               ))}
             </div>
@@ -617,6 +626,7 @@ export function MediaGalleryPanel() {
                   active={activeCategory === 'all'}
                   onClick={() => setActiveCategory('all')}
                   count={allMedia.all.length}
+                  theme={theme}
                 />
                 <CategoryTab
                   icon={Palette}
@@ -624,6 +634,7 @@ export function MediaGalleryPanel() {
                   active={activeCategory === 'art'}
                   onClick={() => setActiveCategory('art')}
                   count={allMedia.art.length}
+                  theme={theme}
                 />
                 <CategoryTab
                   icon={FlaskConical}
@@ -631,6 +642,7 @@ export function MediaGalleryPanel() {
                   active={activeCategory === 'experiment'}
                   onClick={() => setActiveCategory('experiment')}
                   count={allMedia.experiments.length}
+                  theme={theme}
                 />
               </div>
 
@@ -648,9 +660,9 @@ export function MediaGalleryPanel() {
               </div>
 
               {/* 文创作品系列链接 */}
-              <div className="mt-4 pt-4 border-t border-slate-700/50">
+              <div className={`mt-4 pt-4 border-t ${theme === 'dark' ? 'border-slate-700/50' : 'border-gray-200'}`}>
                 <div className="flex items-center justify-between mb-3">
-                  <h4 className="text-xs font-medium text-gray-400 flex items-center gap-2">
+                  <h4 className={`text-xs font-medium flex items-center gap-2 ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}>
                     <Palette className="w-3.5 h-3.5" />
                     {isZh ? '相关文创作品系列' : 'Related Art Series'}
                   </h4>
@@ -668,6 +680,7 @@ export function MediaGalleryPanel() {
                       key={series.id}
                       series={series}
                       isZh={isZh}
+                      theme={theme}
                     />
                   ))}
                 </div>

--- a/src/components/demos/unit3/OpticalRotationDemo.tsx
+++ b/src/components/demos/unit3/OpticalRotationDemo.tsx
@@ -737,7 +737,7 @@ export function OpticalRotationDemo() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* 左侧：可视化 */}
         <div className="space-y-4">
-          <div className="rounded-xl bg-gradient-to-br from-slate-900/90 via-slate-900/95 to-cyan-950/90 border border-cyan-500/30 p-4 shadow-[0_15px_40px_rgba(0,0,0,0.5)]">
+          <div className={`rounded-xl border p-4 ${theme === 'dark' ? 'bg-gradient-to-br from-slate-900/90 via-slate-900/95 to-cyan-950/90 border-cyan-500/30 shadow-[0_15px_40px_rgba(0,0,0,0.5)]' : 'bg-gradient-to-br from-white via-gray-50 to-cyan-50 border-cyan-200 shadow-lg'}`}>
             <OpticalRotationDiagram
               substance={substance}
               concentration={concentration}
@@ -797,7 +797,9 @@ export function OpticalRotationDemo() {
                 className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-colors ${
                   lightMode === 'monochromatic'
                     ? 'bg-amber-500/20 border border-amber-500/50 text-amber-300'
-                    : 'bg-slate-800/50 border border-slate-700 text-gray-400 hover:bg-slate-700/50'
+                    : theme === 'dark'
+                      ? 'bg-slate-800/50 border border-slate-700 text-gray-400 hover:bg-slate-700/50'
+                      : 'bg-gray-100 border border-gray-200 text-gray-600 hover:bg-gray-200'
                 }`}
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
@@ -809,7 +811,9 @@ export function OpticalRotationDemo() {
                 className={`flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-colors ${
                   lightMode === 'polychromatic'
                     ? 'bg-gradient-to-r from-red-500/20 via-green-500/20 to-blue-500/20 border border-white/30 text-white'
-                    : 'bg-slate-800/50 border border-slate-700 text-gray-400 hover:bg-slate-700/50'
+                    : theme === 'dark'
+                      ? 'bg-slate-800/50 border border-slate-700 text-gray-400 hover:bg-slate-700/50'
+                      : 'bg-gray-100 border border-gray-200 text-gray-600 hover:bg-gray-200'
                 }`}
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
@@ -831,7 +835,9 @@ export function OpticalRotationDemo() {
                     className={`w-full py-2 px-3 rounded-lg flex justify-between items-center transition-colors ${
                       selectedWavelength === opt.wavelength
                         ? 'border-2'
-                        : 'bg-slate-800/50 border border-slate-700 text-gray-400 hover:bg-slate-700/50'
+                        : theme === 'dark'
+                          ? 'bg-slate-800/50 border border-slate-700 text-gray-400 hover:bg-slate-700/50'
+                          : 'bg-gray-100 border border-gray-200 text-gray-600 hover:bg-gray-200'
                     }`}
                     style={{
                       borderColor: selectedWavelength === opt.wavelength ? opt.color : undefined,
@@ -874,14 +880,16 @@ export function OpticalRotationDemo() {
                   className={`w-full py-2 px-3 rounded-lg flex justify-between items-center transition-colors ${
                     substance === s.value
                       ? 'bg-cyan-500/20 border border-cyan-500/50 text-cyan-300'
-                      : 'bg-slate-800/50 border border-slate-700 text-gray-400 hover:bg-slate-700/50'
+                      : theme === 'dark'
+                        ? 'bg-slate-800/50 border border-slate-700 text-gray-400 hover:bg-slate-700/50'
+                        : 'bg-gray-100 border border-gray-200 text-gray-600 hover:bg-gray-200'
                   }`}
                   whileHover={{ scale: 1.01 }}
                   whileTap={{ scale: 0.99 }}
                   onClick={() => setSubstance(s.value)}
                 >
                   <span className="font-medium">{s.label}</span>
-                  <span className={`font-mono text-sm ${s.rotation.startsWith('-') ? 'text-pink-400' : 'text-cyan-400'}`}>
+                  <span className={`font-mono text-sm ${s.rotation.startsWith('-') ? 'text-pink-500' : 'text-cyan-500'}`}>
                     [α] = {s.rotation}
                   </span>
                 </motion.button>

--- a/src/components/demos/unit4/MieScatteringDemo.tsx
+++ b/src/components/demos/unit4/MieScatteringDemo.tsx
@@ -5,6 +5,7 @@
  */
 import { useState, useMemo } from 'react'
 import { motion } from 'framer-motion'
+import { useTheme } from '@/contexts/ThemeContext'
 import { SliderControl, ControlPanel, InfoCard } from '../DemoControls'
 
 // 波长到RGB颜色转换
@@ -433,6 +434,7 @@ function SizeParameterChart({
 
 // 主演示组件
 export function MieScatteringDemo() {
+  const { theme } = useTheme()
   const [particleSize, setParticleSize] = useState(0.5) // μm
   const [wavelength, setWavelength] = useState(550) // nm
 
@@ -476,10 +478,10 @@ export function MieScatteringDemo() {
     <div className="space-y-6">
       {/* 标题 */}
       <div className="text-center">
-        <h2 className="text-2xl font-bold bg-gradient-to-r from-white via-pink-100 to-white bg-clip-text text-transparent">
+        <h2 className={`text-2xl font-bold bg-gradient-to-r ${theme === 'dark' ? 'from-white via-pink-100 to-white' : 'from-pink-600 via-pink-500 to-pink-600'} bg-clip-text text-transparent`}>
           米氏散射交互演示
         </h2>
-        <p className="text-gray-400 mt-1">
+        <p className={`${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'} mt-1`}>
           探索粒径与波长可比时的散射特性
         </p>
       </div>
@@ -488,27 +490,27 @@ export function MieScatteringDemo() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* 左侧：可视化 */}
         <div className="space-y-4">
-          <div className="rounded-xl bg-gradient-to-br from-slate-900/90 via-slate-900/95 to-pink-950/90 border border-pink-500/30 p-4 shadow-[0_15px_40px_rgba(0,0,0,0.5)]">
+          <div className={`rounded-xl bg-gradient-to-br ${theme === 'dark' ? 'from-slate-900/90 via-slate-900/95 to-pink-950/90 border-pink-500/30' : 'from-white via-gray-50 to-pink-50 border-pink-200'} border p-4 ${theme === 'dark' ? 'shadow-[0_15px_40px_rgba(0,0,0,0.5)]' : 'shadow-lg'}`}>
             <MieScatteringDiagram particleSize={particleSize} wavelength={wavelength} />
           </div>
 
           {/* 散射特征摘要 */}
-          <div className="rounded-xl bg-gradient-to-br from-slate-900/80 to-slate-800/80 border border-slate-600/30 p-4">
+          <div className={`rounded-xl bg-gradient-to-br ${theme === 'dark' ? 'from-slate-900/80 to-slate-800/80 border-slate-600/30' : 'from-white to-gray-50 border-gray-200'} border p-4`}>
             <div className="grid grid-cols-2 gap-4">
-              <div className="p-3 bg-slate-900/50 rounded-lg text-center">
-                <div className="text-gray-500 text-xs mb-1">尺寸参数 x</div>
+              <div className={`p-3 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'} rounded-lg text-center`}>
+                <div className={`${theme === 'dark' ? 'text-gray-500' : 'text-gray-400'} text-xs mb-1`}>尺寸参数 x</div>
                 <div className={`font-mono text-xl text-${scatterInfo.color}-400`}>
                   {sizeParameter.toFixed(3)}
                 </div>
               </div>
-              <div className="p-3 bg-slate-900/50 rounded-lg text-center">
-                <div className="text-gray-500 text-xs mb-1">散射区域</div>
+              <div className={`p-3 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'} rounded-lg text-center`}>
+                <div className={`${theme === 'dark' ? 'text-gray-500' : 'text-gray-400'} text-xs mb-1`}>散射区域</div>
                 <div className={`font-bold text-lg text-${scatterInfo.color}-400`}>
                   {scatterInfo.type}
                 </div>
               </div>
             </div>
-            <p className="text-xs text-gray-400 mt-3 text-center">
+            <p className={`text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-500'} mt-3 text-center`}>
               {scatterInfo.description}
             </p>
           </div>
@@ -542,13 +544,13 @@ export function MieScatteringDemo() {
 
             {/* 粒子预设 */}
             <div className="pt-2">
-              <div className="text-xs text-gray-500 mb-2">典型粒子</div>
+              <div className={`text-xs ${theme === 'dark' ? 'text-gray-500' : 'text-gray-400'} mb-2`}>典型粒子</div>
               <div className="grid grid-cols-2 gap-2">
                 {presets.map((p) => (
                   <button
                     key={p.name}
                     onClick={() => { setParticleSize(p.size); setWavelength(p.λ) }}
-                    className="px-2 py-1.5 text-xs bg-slate-700/50 text-gray-300 rounded hover:bg-slate-600 transition-colors"
+                    className={`px-2 py-1.5 text-xs ${theme === 'dark' ? 'bg-slate-700/50 text-gray-300 hover:bg-slate-600' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'} rounded transition-colors`}
                   >
                     {p.name}
                   </button>
@@ -560,9 +562,9 @@ export function MieScatteringDemo() {
           {/* 计算结果 */}
           <ControlPanel title="物理参数">
             <div className="space-y-3">
-              <div className="p-3 bg-slate-900/50 rounded-lg">
-                <div className="text-xs text-gray-500 mb-1">尺寸参数公式</div>
-                <div className="font-mono text-sm text-white">
+              <div className={`p-3 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'} rounded-lg`}>
+                <div className={`text-xs ${theme === 'dark' ? 'text-gray-500' : 'text-gray-400'} mb-1`}>尺寸参数公式</div>
+                <div className={`font-mono text-sm ${theme === 'dark' ? 'text-white' : 'text-gray-800'}`}>
                   x = 2πr/λ = 2π × {particleSize.toFixed(3)} × 1000 / {wavelength}
                 </div>
                 <div className={`font-mono text-lg text-${scatterInfo.color}-400 mt-1`}>
@@ -571,12 +573,12 @@ export function MieScatteringDemo() {
               </div>
 
               <div className="grid grid-cols-2 gap-2 text-xs">
-                <div className="p-2 bg-slate-900/50 rounded-lg">
-                  <div className="text-gray-500">粒径/波长</div>
+                <div className={`p-2 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'} rounded-lg`}>
+                  <div className={theme === 'dark' ? 'text-gray-500' : 'text-gray-400'}>粒径/波长</div>
                   <div className="text-cyan-400 font-mono">{((particleSize * 1000) / wavelength).toFixed(3)}</div>
                 </div>
-                <div className="p-2 bg-slate-900/50 rounded-lg">
-                  <div className="text-gray-500">散射效率</div>
+                <div className={`p-2 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'} rounded-lg`}>
+                  <div className={theme === 'dark' ? 'text-gray-500' : 'text-gray-400'}>散射效率</div>
                   <div className="text-pink-400 font-mono">{mieIntensity(sizeParameter).toFixed(2)}</div>
                 </div>
               </div>
@@ -595,7 +597,7 @@ export function MieScatteringDemo() {
 
           {/* 散射特征 */}
           <ControlPanel title="米氏散射特征">
-            <ul className="text-xs text-gray-300 space-y-2">
+            <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-2`}>
               <li className="flex items-start gap-2">
                 <span className="text-pink-400">•</span>
                 <span>前向散射增强：大粒子的散射光主要集中在前进方向</span>
@@ -616,17 +618,17 @@ export function MieScatteringDemo() {
       {/* 知识卡片 */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <InfoCard title="米氏散射理论" color="purple">
-          <p className="text-xs text-gray-300">
+          <p className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
             由Gustav Mie在1908年发展，完整描述球形粒子对电磁波的散射。适用于粒径与波长可比的情况(x≈1-10)。
           </p>
         </InfoCard>
         <InfoCard title="前向散射" color="cyan">
-          <p className="text-xs text-gray-300">
+          <p className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
             米氏散射的显著特征是前向散射增强。粒子越大，散射越集中在前进方向，形成尖锐的前向散射峰。
           </p>
         </InfoCard>
         <InfoCard title="自然现象" color="orange">
-          <ul className="text-xs text-gray-300 space-y-1">
+          <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-1`}>
             <li>• 云和雾的白色</li>
             <li>• 牛奶的乳白色</li>
             <li>• 日晕和虹</li>

--- a/src/components/demos/unit4/MonteCarloScatteringDemo.tsx
+++ b/src/components/demos/unit4/MonteCarloScatteringDemo.tsx
@@ -5,6 +5,7 @@
  */
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react'
 import { motion } from 'framer-motion'
+import { useTheme } from '@/contexts/ThemeContext'
 import { SliderControl, ControlPanel, InfoCard } from '../DemoControls'
 import { Play, Pause, RotateCcw } from 'lucide-react'
 
@@ -310,9 +311,11 @@ function PhotonVisualization({
 function ScatteringStats({
   photons,
   mediumWidth,
+  theme,
 }: {
   photons: Photon[]
   mediumWidth: number
+  theme: string
 }) {
   const stats = useMemo(() => {
     const transmitted = photons.filter(p => !p.alive && p.x >= mediumWidth)
@@ -342,21 +345,21 @@ function ScatteringStats({
 
   return (
     <div className="grid grid-cols-2 gap-2 text-xs">
-      <div className="p-2 bg-slate-900/50 rounded-lg">
-        <div className="text-gray-500">透射率</div>
+      <div className={`p-2 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'} rounded-lg`}>
+        <div className={theme === 'dark' ? 'text-gray-500' : 'text-gray-400'}>透射率</div>
         <div className="text-emerald-400 font-mono text-lg">{stats.transmittance}%</div>
       </div>
-      <div className="p-2 bg-slate-900/50 rounded-lg">
-        <div className="text-gray-500">平均散射次数</div>
+      <div className={`p-2 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'} rounded-lg`}>
+        <div className={theme === 'dark' ? 'text-gray-500' : 'text-gray-400'}>平均散射次数</div>
         <div className="text-pink-400 font-mono text-lg">{stats.avgScattering}</div>
       </div>
-      <div className="p-2 bg-slate-900/50 rounded-lg">
-        <div className="text-gray-500">透射光偏振角</div>
+      <div className={`p-2 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'} rounded-lg`}>
+        <div className={theme === 'dark' ? 'text-gray-500' : 'text-gray-400'}>透射光偏振角</div>
         <div className="text-cyan-400 font-mono text-lg">{stats.avgPolarization}°</div>
       </div>
-      <div className="p-2 bg-slate-900/50 rounded-lg">
-        <div className="text-gray-500">状态分布</div>
-        <div className="text-gray-300 font-mono text-sm">
+      <div className={`p-2 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'} rounded-lg`}>
+        <div className={theme === 'dark' ? 'text-gray-500' : 'text-gray-400'}>状态分布</div>
+        <div className={`${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} font-mono text-sm`}>
           T:{stats.transmitted} R:{stats.reflected} A:{stats.absorbed}
         </div>
       </div>
@@ -366,6 +369,7 @@ function ScatteringStats({
 
 // 主演示组件
 export function MonteCarloScatteringDemo() {
+  const { theme } = useTheme()
   const [meanFreePath, setMeanFreePath] = useState(0.5) // 平均自由程
   const [anisotropy, setAnisotropy] = useState(0.8) // 各向异性因子 g
   const [albedo, setAlbedo] = useState(0.9) // 单次散射反照率
@@ -458,10 +462,10 @@ export function MonteCarloScatteringDemo() {
     <div className="space-y-6">
       {/* 标题 */}
       <div className="text-center">
-        <h2 className="text-2xl font-bold bg-gradient-to-r from-white via-cyan-100 to-white bg-clip-text text-transparent">
+        <h2 className={`text-2xl font-bold bg-gradient-to-r ${theme === 'dark' ? 'from-white via-cyan-100 to-white' : 'from-cyan-600 via-cyan-500 to-cyan-600'} bg-clip-text text-transparent`}>
           蒙特卡洛散射模拟
         </h2>
-        <p className="text-gray-400 mt-1">
+        <p className={`${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'} mt-1`}>
           光子在浑浊介质中的随机行走与多次散射
         </p>
       </div>
@@ -470,7 +474,7 @@ export function MonteCarloScatteringDemo() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* 左侧：可视化 */}
         <div className="space-y-4">
-          <div className="rounded-xl bg-gradient-to-br from-slate-900/90 via-slate-900/95 to-cyan-950/90 border border-cyan-500/30 p-4 shadow-[0_15px_40px_rgba(0,0,0,0.5)]">
+          <div className={`rounded-xl bg-gradient-to-br ${theme === 'dark' ? 'from-slate-900/90 via-slate-900/95 to-cyan-950/90 border-cyan-500/30' : 'from-white via-gray-50 to-cyan-50 border-cyan-200'} border p-4 ${theme === 'dark' ? 'shadow-[0_15px_40px_rgba(0,0,0,0.5)]' : 'shadow-lg'}`}>
             <PhotonVisualization
               photons={photons}
               mediumWidth={mediumWidth}
@@ -496,7 +500,7 @@ export function MonteCarloScatteringDemo() {
             </motion.button>
             <motion.button
               onClick={reset}
-              className="px-6 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-white flex items-center gap-2 font-medium"
+              className={`px-6 py-2 rounded-lg ${theme === 'dark' ? 'bg-slate-700 hover:bg-slate-600' : 'bg-gray-200 hover:bg-gray-300'} ${theme === 'dark' ? 'text-white' : 'text-gray-700'} flex items-center gap-2 font-medium`}
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
             >
@@ -506,9 +510,9 @@ export function MonteCarloScatteringDemo() {
           </div>
 
           {/* 统计信息 */}
-          <div className="rounded-xl bg-gradient-to-br from-slate-900/80 to-slate-800/80 border border-slate-600/30 p-4">
-            <h3 className="text-sm font-medium text-gray-300 mb-3">模拟统计</h3>
-            <ScatteringStats photons={photons} mediumWidth={mediumWidth} />
+          <div className={`rounded-xl bg-gradient-to-br ${theme === 'dark' ? 'from-slate-900/80 to-slate-800/80 border-slate-600/30' : 'from-white to-gray-50 border-gray-200'} border p-4`}>
+            <h3 className={`text-sm font-medium ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} mb-3`}>模拟统计</h3>
+            <ScatteringStats photons={photons} mediumWidth={mediumWidth} theme={theme} />
           </div>
         </div>
 
@@ -559,12 +563,12 @@ export function MonteCarloScatteringDemo() {
 
           {/* 显示选项 */}
           <ControlPanel title="显示选项">
-            <label className="flex items-center gap-2 text-sm text-gray-300">
+            <label className={`flex items-center gap-2 text-sm ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
               <input
                 type="checkbox"
                 checked={showPolarization}
                 onChange={(e) => setShowPolarization(e.target.checked)}
-                className="w-4 h-4 rounded border-gray-600 bg-slate-800"
+                className={`w-4 h-4 rounded ${theme === 'dark' ? 'border-gray-600 bg-slate-800' : 'border-gray-300 bg-white'}`}
               />
               显示偏振状态（颜色编码）
             </label>
@@ -572,16 +576,16 @@ export function MonteCarloScatteringDemo() {
 
           {/* 参数说明 */}
           <ControlPanel title="参数说明">
-            <div className="space-y-3 text-xs text-gray-300">
-              <div className="p-2 bg-slate-900/50 rounded-lg">
+            <div className={`space-y-3 text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
+              <div className={`p-2 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'} rounded-lg`}>
                 <span className="text-cyan-400 font-medium">平均自由程 (MFP):</span>
                 <p className="mt-1">光子两次散射事件之间的平均距离。值越小，散射越频繁，介质越浑浊。</p>
               </div>
-              <div className="p-2 bg-slate-900/50 rounded-lg">
+              <div className={`p-2 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'} rounded-lg`}>
                 <span className="text-pink-400 font-medium">各向异性因子 (g):</span>
                 <p className="mt-1">g=0 各向同性散射，g&gt;0 前向散射为主，g&lt;0 后向散射为主。云滴 g≈0.85。</p>
               </div>
-              <div className="p-2 bg-slate-900/50 rounded-lg">
+              <div className={`p-2 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'} rounded-lg`}>
                 <span className="text-emerald-400 font-medium">单次散射反照率 (ω):</span>
                 <p className="mt-1">散射/(散射+吸收)，ω=1 无吸收，ω&lt;1 部分吸收。</p>
               </div>
@@ -590,7 +594,7 @@ export function MonteCarloScatteringDemo() {
 
           {/* MC方法原理 */}
           <ControlPanel title="蒙特卡洛方法原理">
-            <ul className="text-xs text-gray-300 space-y-2">
+            <ul className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} space-y-2`}>
               <li className="flex items-start gap-2">
                 <span className="text-cyan-400">1.</span>
                 <span>光子从入射面进入介质，初始方向沿入射方向</span>
@@ -619,17 +623,17 @@ export function MonteCarloScatteringDemo() {
       {/* 知识卡片 */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <InfoCard title="蒙特卡洛模拟" color="cyan">
-          <p className="text-xs text-gray-300">
+          <p className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
             Monte Carlo方法通过随机采样模拟物理过程。在光传输中，每个光子独立追踪，大量光子的统计结果收敛于解析解。适用于复杂几何和多次散射。
           </p>
         </InfoCard>
         <InfoCard title="Henyey-Greenstein相函数" color="purple">
-          <p className="text-xs text-gray-300">
+          <p className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
             HG相函数 p(θ) = (1-g²)/(1+g²-2g·cosθ)^(3/2) 用单参数g描述散射的方向分布。生物组织典型值 g=0.8-0.95，云滴 g≈0.85。
           </p>
         </InfoCard>
         <InfoCard title="偏振退极化" color="orange">
-          <p className="text-xs text-gray-300">
+          <p className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
             多次散射导致偏振态随机化（退极化）。入射偏振光经过多次散射后趋于非偏振。透射光的偏振度与散射次数、各向异性相关。
           </p>
         </InfoCard>

--- a/src/components/demos/unit4/RayleighScatteringDemo.tsx
+++ b/src/components/demos/unit4/RayleighScatteringDemo.tsx
@@ -6,6 +6,7 @@
 import { useState, useMemo } from 'react'
 import { motion } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/contexts/ThemeContext'
 import { SliderControl, ControlPanel, InfoCard, ValueDisplay, Toggle } from '../DemoControls'
 
 // 瑞利散射强度 (与λ^-4成正比)
@@ -606,7 +607,7 @@ function PolarizationAngleChart({ currentAngle }: { currentAngle: number }) {
 }
 
 // 散射强度对比柱状图
-function ScatteringIntensityBars() {
+function ScatteringIntensityBars({ theme }: { theme: string }) {
   const wavelengths = [
     { wl: 450, label: '蓝光', color: '#3b82f6' },
     { wl: 550, label: '绿光', color: '#22c55e' },
@@ -625,9 +626,9 @@ function ScatteringIntensityBars() {
           <div key={i} className="space-y-1">
             <div className="flex justify-between text-xs">
               <span style={{ color: item.color }}>{item.label} ({item.wl}nm)</span>
-              <span className="text-gray-400">{intensity.toFixed(2)}</span>
+              <span className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>{intensity.toFixed(2)}</span>
             </div>
-            <div className="h-3 bg-slate-700 rounded-full overflow-hidden">
+            <div className={`h-3 ${theme === 'dark' ? 'bg-slate-700' : 'bg-gray-200'} rounded-full overflow-hidden`}>
               <motion.div
                 className="h-full rounded-full"
                 style={{ backgroundColor: item.color }}
@@ -639,7 +640,7 @@ function ScatteringIntensityBars() {
           </div>
         )
       })}
-      <p className="text-xs text-gray-500 mt-2 text-center">
+      <p className={`text-xs ${theme === 'dark' ? 'text-gray-500' : 'text-gray-400'} mt-2 text-center`}>
         蓝光散射约为红光的 {(rayleighIntensity(450) / rayleighIntensity(650)).toFixed(1)} 倍
       </p>
     </div>
@@ -649,6 +650,7 @@ function ScatteringIntensityBars() {
 // 主演示组件
 export function RayleighScatteringDemo() {
   const { t: _t } = useTranslation() // Reserved for future i18n
+  const { theme } = useTheme()
   const [sunAngle, setSunAngle] = useState(60)
   const [observerAngle, setObserverAngle] = useState(45)
   const [showPolarization, setShowPolarization] = useState(true)
@@ -671,10 +673,10 @@ export function RayleighScatteringDemo() {
     <div className="flex flex-col gap-6">
       {/* 标题 */}
       <div className="text-center">
-        <h2 className="text-2xl font-bold bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent">
+        <h2 className={`text-2xl font-bold bg-gradient-to-r ${theme === 'dark' ? 'from-cyan-400 to-blue-500' : 'from-cyan-600 to-blue-600'} bg-clip-text text-transparent`}>
           瑞利散射演示
         </h2>
-        <p className="text-gray-400 text-sm mt-1">Rayleigh Scattering - 蓝天与红日的秘密</p>
+        <p className={`${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'} text-sm mt-1`}>Rayleigh Scattering - 蓝天与红日的秘密</p>
       </div>
 
       {/* 主要内容区 */}
@@ -682,8 +684,8 @@ export function RayleighScatteringDemo() {
         {/* 左侧：可视化 */}
         <div className="space-y-4">
           {/* 散射场景 */}
-          <div className="bg-slate-900/50 rounded-xl border border-cyan-400/20 p-4">
-            <h3 className="text-sm font-medium text-cyan-400 mb-3">大气散射场景</h3>
+          <div className={`${theme === 'dark' ? 'bg-slate-900/50 border-cyan-400/20' : 'bg-white border-cyan-200 shadow-sm'} rounded-xl border p-4`}>
+            <h3 className={`text-sm font-medium ${theme === 'dark' ? 'text-cyan-400' : 'text-cyan-600'} mb-3`}>大气散射场景</h3>
             <div className="aspect-[16/10]">
               <RayleighDiagram
                 sunAngle={sunAngle}
@@ -695,12 +697,12 @@ export function RayleighScatteringDemo() {
 
           {/* 图表区 */}
           <div className="grid grid-cols-2 gap-4">
-            <div className="bg-slate-900/50 rounded-xl border border-cyan-400/20 p-3">
-              <h4 className="text-xs font-medium text-cyan-400 mb-2">波长依赖性 (λ⁻⁴)</h4>
+            <div className={`${theme === 'dark' ? 'bg-slate-900/50 border-cyan-400/20' : 'bg-white border-cyan-200 shadow-sm'} rounded-xl border p-3`}>
+              <h4 className={`text-xs font-medium ${theme === 'dark' ? 'text-cyan-400' : 'text-cyan-600'} mb-2`}>波长依赖性 (λ⁻⁴)</h4>
               <WavelengthDependenceChart />
             </div>
-            <div className="bg-slate-900/50 rounded-xl border border-cyan-400/20 p-3">
-              <h4 className="text-xs font-medium text-cyan-400 mb-2">偏振度 vs 散射角</h4>
+            <div className={`${theme === 'dark' ? 'bg-slate-900/50 border-cyan-400/20' : 'bg-white border-cyan-200 shadow-sm'} rounded-xl border p-3`}>
+              <h4 className={`text-xs font-medium ${theme === 'dark' ? 'text-cyan-400' : 'text-cyan-600'} mb-2`}>偏振度 vs 散射角</h4>
               <PolarizationAngleChart currentAngle={scatterAngle} />
             </div>
           </div>
@@ -739,7 +741,7 @@ export function RayleighScatteringDemo() {
                   className={`flex-1 px-3 py-1.5 rounded text-xs transition-colors ${
                     sunAngle === preset.angle
                       ? 'bg-cyan-500 text-white'
-                      : 'bg-slate-700 text-gray-300 hover:bg-slate-600'
+                      : theme === 'dark' ? 'bg-slate-700 text-gray-300 hover:bg-slate-600' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
                   }`}
                 >
                   {preset.label}
@@ -762,13 +764,13 @@ export function RayleighScatteringDemo() {
               unit="%"
               color={polarization > 0.8 ? 'green' : 'cyan'}
             />
-            <div className="mt-2 p-2 bg-slate-800/50 rounded text-center">
-              <span className="text-yellow-400 font-mono text-lg">I ∝ λ⁻⁴</span>
+            <div className={`mt-2 p-2 ${theme === 'dark' ? 'bg-slate-800/50' : 'bg-gray-50'} rounded text-center`}>
+              <span className={`${theme === 'dark' ? 'text-yellow-400' : 'text-yellow-600'} font-mono text-lg`}>I ∝ λ⁻⁴</span>
             </div>
           </ControlPanel>
 
           <ControlPanel title="各波长相对散射强度">
-            <ScatteringIntensityBars />
+            <ScatteringIntensityBars theme={theme} />
           </ControlPanel>
         </div>
       </div>
@@ -776,7 +778,7 @@ export function RayleighScatteringDemo() {
       {/* 底部知识卡片 */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <InfoCard title="瑞利散射特性" color="cyan">
-          <ul className="text-sm space-y-1 text-gray-300">
+          <ul className={`text-sm space-y-1 ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
             <li>• <strong>适用条件：</strong>粒径 ≪ 波长（空气分子 ~0.3nm）</li>
             <li>• <strong>波长依赖：</strong>I ∝ λ⁻⁴（短波散射更强）</li>
             <li>• <strong>偏振特性：</strong>90°散射时完全线偏振</li>
@@ -785,7 +787,7 @@ export function RayleighScatteringDemo() {
         </InfoCard>
 
         <InfoCard title="自然现象解释" color="blue">
-          <ul className="text-sm space-y-1 text-gray-300">
+          <ul className={`text-sm space-y-1 ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
             <li>• <strong>蓝天：</strong>蓝光散射是红光的~10倍，充满天空</li>
             <li>• <strong>红日落：</strong>阳光穿过更多大气，蓝光散射殆尽</li>
             <li>• <strong>天空偏振：</strong>与太阳成90°方向偏振最强</li>

--- a/src/components/demos/unit5/PolarimetricMicroscopyDemo.tsx
+++ b/src/components/demos/unit5/PolarimetricMicroscopyDemo.tsx
@@ -5,6 +5,7 @@
  */
 import { useState, useMemo } from 'react'
 import { motion } from 'framer-motion'
+import { useTheme } from '@/contexts/ThemeContext'
 import { SliderControl, ControlPanel, InfoCard } from '../DemoControls'
 import { Microscope, Grid3X3, Layers } from 'lucide-react'
 
@@ -224,9 +225,11 @@ function MicroscopyImage({
 function MuellerMatrixDisplay({
   matrix,
   highlight,
+  theme,
 }: {
   matrix: number[][]
   highlight?: [number, number]
+  theme: string
 }) {
   return (
     <div className="grid grid-cols-4 gap-1">
@@ -237,14 +240,14 @@ function MuellerMatrixDisplay({
             className={`p-1.5 rounded text-center font-mono text-xs ${highlight && highlight[0] === i && highlight[1] === j
                 ? 'bg-cyan-600 text-white'
                 : i === 0 || j === 0
-                  ? 'bg-slate-700 text-cyan-400'
-                  : 'bg-slate-800 text-gray-300'
+                  ? theme === 'dark' ? 'bg-slate-700 text-cyan-400' : 'bg-gray-200 text-cyan-600'
+                  : theme === 'dark' ? 'bg-slate-800 text-gray-300' : 'bg-gray-100 text-gray-700'
               }`}
             initial={{ scale: 0.8 }}
             animate={{ scale: 1 }}
             whileHover={{ scale: 1.1 }}
           >
-            <div className="text-[8px] text-gray-500">{MUELLER_NAMES[i][j]}</div>
+            <div className={`text-[8px] ${theme === 'dark' ? 'text-gray-500' : 'text-gray-400'}`}>{MUELLER_NAMES[i][j]}</div>
             <div>{val.toFixed(2)}</div>
           </motion.div>
         ))
@@ -260,24 +263,26 @@ function ParamBar({
   max,
   color,
   unit,
+  theme,
 }: {
   label: string
   value: number
   max: number
   color: string
   unit?: string
+  theme: string
 }) {
   const percentage = Math.min((value / max) * 100, 100)
 
   return (
     <div className="space-y-1">
       <div className="flex justify-between text-xs">
-        <span className="text-gray-400">{label}</span>
+        <span className={theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}>{label}</span>
         <span className={`font-mono text-${color}-400`}>
           {value.toFixed(2)}{unit}
         </span>
       </div>
-      <div className="h-2 bg-slate-700 rounded-full overflow-hidden">
+      <div className={`h-2 ${theme === 'dark' ? 'bg-slate-700' : 'bg-gray-200'} rounded-full overflow-hidden`}>
         <motion.div
           className={`h-full bg-${color}-500`}
           initial={{ width: 0 }}
@@ -291,6 +296,7 @@ function ParamBar({
 
 // Main demo component
 export function PolarimetricMicroscopyDemo() {
+  const { theme } = useTheme()
   const [sampleType, setSampleType] = useState<SampleType>('fiber')
   const [showOverlay, setShowOverlay] = useState(true)
   const [overlayType, setOverlayType] = useState<'retardance' | 'depol' | 'diattenuation'>('retardance')
@@ -304,10 +310,10 @@ export function PolarimetricMicroscopyDemo() {
     <div className="space-y-6">
       {/* Header */}
       <div className="text-center">
-        <h2 className="text-2xl font-bold bg-gradient-to-r from-white via-violet-100 to-white bg-clip-text text-transparent">
+        <h2 className={`text-2xl font-bold bg-gradient-to-r ${theme === 'dark' ? 'from-white via-violet-100 to-white' : 'from-violet-600 via-violet-500 to-violet-600'} bg-clip-text text-transparent`}>
           全偏振显微成像
         </h2>
-        <p className="text-gray-400 mt-1">
+        <p className={`${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'} mt-1`}>
           Mueller矩阵显微镜的工作原理与应用
         </p>
       </div>
@@ -316,16 +322,16 @@ export function PolarimetricMicroscopyDemo() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Left: Microscopy view */}
         <div className="space-y-4">
-          <div className="rounded-xl bg-gradient-to-br from-slate-900/90 via-slate-900/95 to-violet-950/90 border border-violet-500/30 p-4">
+          <div className={`rounded-xl bg-gradient-to-br ${theme === 'dark' ? 'from-slate-900/90 via-slate-900/95 to-violet-950/90 border-violet-500/30' : 'from-white via-gray-50 to-violet-50 border-violet-200'} border p-4`}>
             <div className="flex items-center justify-between mb-3">
               <div className="flex items-center gap-2">
                 <Microscope className="w-5 h-5 text-violet-400" />
-                <span className="text-sm font-medium text-gray-300">Mueller显微成像</span>
+                <span className={`text-sm font-medium ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>Mueller显微成像</span>
               </div>
               <div className="flex gap-2">
                 <button
                   onClick={() => setShowOverlay(!showOverlay)}
-                  className={`px-2 py-1 text-xs rounded flex items-center gap-1 transition-colors ${showOverlay ? 'bg-violet-600 text-white' : 'bg-slate-700 text-gray-400'
+                  className={`px-2 py-1 text-xs rounded flex items-center gap-1 transition-colors ${showOverlay ? 'bg-violet-600 text-white' : theme === 'dark' ? 'bg-slate-700 text-gray-400' : 'bg-gray-200 text-gray-500'
                     }`}
                 >
                   <Layers size={12} />
@@ -354,7 +360,7 @@ export function PolarimetricMicroscopyDemo() {
                   onClick={() => setOverlayType(type)}
                   className={`px-3 py-1.5 text-xs rounded-full transition-colors ${overlayType === type
                       ? `bg-${color}-600 text-white`
-                      : 'bg-slate-700 text-gray-400 hover:bg-slate-600'
+                      : theme === 'dark' ? 'bg-slate-700 text-gray-400 hover:bg-slate-600' : 'bg-gray-200 text-gray-500 hover:bg-gray-300'
                     }`}
                 >
                   {label}
@@ -364,16 +370,16 @@ export function PolarimetricMicroscopyDemo() {
           )}
 
           {/* Polarization parameters */}
-          <div className="rounded-xl bg-slate-800/50 border border-slate-700 p-4">
-            <h3 className="text-sm font-medium text-gray-300 mb-3 flex items-center gap-2">
+          <div className={`rounded-xl ${theme === 'dark' ? 'bg-slate-800/50 border-slate-700' : 'bg-white border-gray-200'} border p-4`}>
+            <h3 className={`text-sm font-medium ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} mb-3 flex items-center gap-2`}>
               <Grid3X3 size={16} className="text-violet-400" />
               偏振参数提取
             </h3>
             <div className="space-y-3">
-              <ParamBar label="线性延迟 R" value={params.R} max={180} color="cyan" unit="°" />
-              <ParamBar label="退偏振指数" value={params.depol} max={1} color="green" />
-              <ParamBar label="二向衰减 D" value={params.D} max={1} color="orange" />
-              <ParamBar label="偏振度 DOP" value={params.dop} max={1} color="pink" />
+              <ParamBar label="线性延迟 R" value={params.R} max={180} color="cyan" unit="°" theme={theme} />
+              <ParamBar label="退偏振指数" value={params.depol} max={1} color="green" theme={theme} />
+              <ParamBar label="二向衰减 D" value={params.D} max={1} color="orange" theme={theme} />
+              <ParamBar label="偏振度 DOP" value={params.dop} max={1} color="pink" theme={theme} />
             </div>
           </div>
         </div>
@@ -389,7 +395,7 @@ export function PolarimetricMicroscopyDemo() {
                   onClick={() => setSampleType(type)}
                   className={`p-3 rounded-lg text-left transition-all ${sampleType === type
                       ? 'bg-violet-600/30 border border-violet-500'
-                      : 'bg-slate-800/50 border border-slate-700 hover:border-slate-500'
+                      : theme === 'dark' ? 'bg-slate-800/50 border border-slate-700 hover:border-slate-500' : 'bg-gray-100 border border-gray-200 hover:border-gray-300'
                     }`}
                 >
                   <div className="flex items-center gap-2">
@@ -397,11 +403,11 @@ export function PolarimetricMicroscopyDemo() {
                       className="w-3 h-3 rounded-full"
                       style={{ backgroundColor: SAMPLES[type].color }}
                     />
-                    <span className="text-sm font-medium text-white">
+                    <span className={`text-sm font-medium ${theme === 'dark' ? 'text-white' : 'text-gray-800'}`}>
                       {SAMPLES[type].nameZh}
                     </span>
                   </div>
-                  <p className="text-xs text-gray-400 mt-1">
+                  <p className={`text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-500'} mt-1`}>
                     {SAMPLES[type].descriptionZh}
                   </p>
                 </button>
@@ -414,8 +420,9 @@ export function PolarimetricMicroscopyDemo() {
             <MuellerMatrixDisplay
               matrix={sample.muellerMatrix}
               highlight={highlightElement}
+              theme={theme}
             />
-            <div className="mt-3 text-xs text-gray-400">
+            <div className={`mt-3 text-xs ${theme === 'dark' ? 'text-gray-400' : 'text-gray-500'}`}>
               <p>• M₀₀: 总强度透过率</p>
               <p>• 对角元素: 偏振保持特性</p>
               <p>• 非对角元素: 偏振转换特性</p>
@@ -438,16 +445,16 @@ export function PolarimetricMicroscopyDemo() {
 
           {/* Microscope setup */}
           <ControlPanel title="显微镜原理">
-            <div className="space-y-2 text-xs text-gray-300">
-              <div className="p-2 bg-slate-900/50 rounded-lg">
+            <div className={`space-y-2 text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
+              <div className={`p-2 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'} rounded-lg`}>
                 <span className="text-violet-400 font-medium">照明臂:</span>
                 <p className="mt-1">偏振态发生器(PSG)产生4种已知偏振态照明样品</p>
               </div>
-              <div className="p-2 bg-slate-900/50 rounded-lg">
+              <div className={`p-2 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'} rounded-lg`}>
                 <span className="text-violet-400 font-medium">探测臂:</span>
                 <p className="mt-1">偏振态分析器(PSA)分析出射光的偏振态</p>
               </div>
-              <div className="p-2 bg-slate-900/50 rounded-lg">
+              <div className={`p-2 ${theme === 'dark' ? 'bg-slate-900/50' : 'bg-gray-100'} rounded-lg`}>
                 <span className="text-violet-400 font-medium">数据处理:</span>
                 <p className="mt-1">16次测量重建完整4×4 Mueller矩阵</p>
               </div>
@@ -459,17 +466,17 @@ export function PolarimetricMicroscopyDemo() {
       {/* Knowledge cards */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <InfoCard title="Mueller矩阵显微镜" color="purple">
-          <p className="text-xs text-gray-300">
+          <p className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
             通过测量样品的完整4×4 Mueller矩阵，可以获得样品的所有偏振特性信息，包括双折射、二向衰减、退偏振等，是最完备的偏振成像技术。
           </p>
         </InfoCard>
         <InfoCard title="生物医学应用" color="orange">
-          <p className="text-xs text-gray-300">
+          <p className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
             用于肿瘤边界识别、胶原纤维取向分析、眼科角膜检测等。偏振参数可提供组织微结构的定量信息，辅助临床诊断。
           </p>
         </InfoCard>
         <InfoCard title="材料表征" color="cyan">
-          <p className="text-xs text-gray-300">
+          <p className={`text-xs ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
             分析材料内部应力分布、液晶取向、薄膜厚度等。Mueller矩阵分解可提取双折射、旋光、退偏振等独立参数。
           </p>
         </InfoCard>


### PR DESCRIPTION
- Update Demo2DCanvas.tsx with theme-aware background
- Update DemoErrorBoundary.tsx with theme-aware colors
- Update SourceCodeViewer.tsx with full light mode support
- Update LanguageSelector.tsx with theme support
- Update PolarizationIntroDemo.tsx with comprehensive theme support
- Update all basics unit demos (LightWaveDemo, ElectromagneticWaveDemo, ElectromagneticSpectrumDemo, PolarizationTypesDemo, PolarizationTypesUnifiedDemo, MalusLawGraphDemo, ThreePolarizersDemo, InteractiveOpticalBenchDemo)
- Update all unit1 demos (MalusLawDemo, AragoFresnelDemo, BirefringenceDemo, WaveplateDemo, PolarizationStateDemo)
- Update all unit2 demos (FresnelDemo, BrewsterDemo)
- Update all unit3 demos (ChromaticDemo, OpticalRotationDemo, MediaGalleryPanel)
- Update all unit4 demos (RayleighScatteringDemo, MieScatteringDemo, MonteCarloScatteringDemo)
- Update unit5 PolarimetricMicroscopyDemo

All demo cards and interactive components now properly respond to theme switching between dark and light modes.