### PR TITLE
fix: correct scientific accuracy of light physics models

### DIFF
--- a/src/components/museum/MuseumHomepage.tsx
+++ b/src/components/museum/MuseumHomepage.tsx
@@ -1165,15 +1165,34 @@ function MuseumFooter() {
             )}>
               {t('museum.footer.tagline')}
             </p>
-            {/* Polarization visual */}
-            <div className="flex gap-1">
-              {POLARIZATION_COLORS.map((color, i) => (
-                <div
-                  key={i}
-                  className="w-4 h-4 rounded-full"
-                  style={{ backgroundColor: color, opacity: 0.8 }}
-                />
-              ))}
+            {/* Polarization visual with disclaimer tooltip */}
+            <div className="group relative">
+              <div className="flex gap-1 cursor-help">
+                {POLARIZATION_COLORS.map((color, i) => (
+                  <div
+                    key={i}
+                    className="w-4 h-4 rounded-full"
+                    style={{ backgroundColor: color, opacity: 0.8 }}
+                  />
+                ))}
+              </div>
+              {/* Tooltip disclaimer for false colors */}
+              <div className={cn(
+                "absolute bottom-full left-0 mb-2 px-3 py-2 rounded-lg text-xs w-64",
+                "opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200",
+                "z-50 pointer-events-none",
+                theme === 'dark'
+                  ? "bg-slate-700 text-slate-200 border border-slate-600"
+                  : "bg-white text-slate-700 border border-slate-200 shadow-lg"
+              )}>
+                <div className="font-semibold mb-1 flex items-center gap-1">
+                  <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  {t('museum.colorDisclaimer.title', 'Visual Note')}
+                </div>
+                <p>{t('museum.colorDisclaimer.description', 'These colors represent polarization direction (0°, 45°, 90°, 135°), not actual light wavelength. False colors are used for visualization purposes.')}</p>
+              </div>
             </div>
           </div>
 
@@ -1245,7 +1264,7 @@ function MuseumFooter() {
               </li>
               <li>
                 <a
-                  href="https://github.com/openwisdomlab/polarisation"
+                  href="https://github.com/openwisdomlab/polarisationcourse"
                   target="_blank"
                   rel="noopener noreferrer"
                   className={cn(
@@ -1284,7 +1303,7 @@ function MuseumFooter() {
               </li>
               <li>
                 <a
-                  href="https://github.com/openwisdomlab/polarisation/blob/main/CONTRIBUTING.md"
+                  href="https://github.com/openwisdomlab/polarisationcourse/blob/main/CONTRIBUTING.md"
                   target="_blank"
                   rel="noopener noreferrer"
                   className={cn(

--- a/src/components/museum/PolarizationLawsSection.tsx
+++ b/src/components/museum/PolarizationLawsSection.tsx
@@ -197,7 +197,9 @@ function MalusVisualization({ isActive }: { isActive: boolean }) {
   )
 }
 
-// Birefringence Visualization - Crystal splitting light
+// Birefringence Visualization - Polarizing Beam Splitter (PBS)
+// NOTE: This visualization shows 90° beam separation (like PBS/Wollaston Prism),
+// NOT natural calcite crystal which has ~6° walk-off angle.
 function BirefringenceVisualization({ isActive }: { isActive: boolean }) {
   const [time, setTime] = useState(0)
 
@@ -222,7 +224,7 @@ function BirefringenceVisualization({ isActive }: { isActive: boolean }) {
         </linearGradient>
       </defs>
 
-      {/* Crystal (calcite) */}
+      {/* PBS Cube */}
       <polygon
         points="35,25 65,25 70,75 30,75"
         fill="url(#crystal-fill)"
@@ -231,19 +233,17 @@ function BirefringenceVisualization({ isActive }: { isActive: boolean }) {
         opacity="0.8"
       />
 
-      {/* Crystal pattern lines */}
-      {[30, 40, 50, 60].map((x, i) => (
-        <line
-          key={i}
-          x1={x + 2}
-          y1="28"
-          x2={x - 3}
-          y2="72"
-          stroke="#a78bfa"
-          strokeWidth="0.3"
-          opacity="0.4"
-        />
-      ))}
+      {/* Diagonal interface line (characteristic of PBS) */}
+      <line
+        x1="35"
+        y1="25"
+        x2="70"
+        y2="75"
+        stroke="#a78bfa"
+        strokeWidth="1"
+        strokeDasharray="2,1"
+        opacity="0.6"
+      />
 
       {/* Input beam (unpolarized/mixed) */}
       <rect x="5" y="46" width="28" height="8" fill="#ffffff" opacity="0.8" rx="1">
@@ -255,7 +255,7 @@ function BirefringenceVisualization({ isActive }: { isActive: boolean }) {
         />
       </rect>
 
-      {/* O-ray (ordinary ray - 0°) */}
+      {/* p-ray (transmitted - horizontal polarization) */}
       {showSplit && (
         <g>
           <line
@@ -268,11 +268,11 @@ function BirefringenceVisualization({ isActive }: { isActive: boolean }) {
             strokeLinecap="round"
             opacity={isActive ? 0.9 : 0.5}
           />
-          <text x="88" y="35" fontSize="4" fill="#ff4444">o-ray (0°)</text>
+          <text x="88" y="35" fontSize="4" fill="#ff4444">p (0°)</text>
         </g>
       )}
 
-      {/* E-ray (extraordinary ray - 90°) */}
+      {/* s-ray (reflected - vertical polarization) */}
       {showSplit && (
         <g>
           <line
@@ -285,13 +285,13 @@ function BirefringenceVisualization({ isActive }: { isActive: boolean }) {
             strokeLinecap="round"
             opacity={isActive ? 0.9 : 0.5}
           />
-          <text x="88" y="68" fontSize="4" fill="#44ff44">e-ray (90°)</text>
+          <text x="88" y="68" fontSize="4" fill="#44ff44">s (90°)</text>
         </g>
       )}
 
-      {/* Labels */}
+      {/* Labels - PBS instead of Calcite */}
       <text x="50" y="18" textAnchor="middle" fontSize="4" fill="#a78bfa" opacity="0.8">
-        Calcite
+        PBS
       </text>
     </svg>
   )

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -19,21 +19,32 @@ export interface LightPacket {
   phase: Phase;
 }
 
-// 方块类型 - 扩展版
+/**
+ * 方块类型 - 扩展版
+ *
+ * ⚠️ SCIENTIFIC NOTE: This game uses SIMPLIFIED physics models for some components.
+ * For scientifically accurate simulations, use the Jones Calculus engine in WaveOptics.ts.
+ *
+ * Key simplifications in the game engine (LightPhysics.ts):
+ * - quarterWave: Acts as 45° rotator, NOT true QWP (no circular polarization)
+ * - halfWave: Acts as 90° rotator, NOT true HWP (no fast-axis dependent rotation)
+ * - splitter: 90° separation like PBS/Wollaston, NOT natural calcite (~6° walk-off)
+ * - Phase: Binary (±1) only, NOT continuous (0-2π radians)
+ */
 export type BlockType =
   | 'air'
   | 'solid'
   | 'emitter'        // 光源 - 发射偏振光
   | 'polarizer'      // 偏振片 - 马吕斯定律过滤
   | 'rotator'        // 波片（旋光器）- 旋转偏振角度
-  | 'splitter'       // 方解石（双折射晶体）- 分裂o光和e光
+  | 'splitter'       // ⚠️ 偏振分束器(PBS) - 90°分束 (非天然方解石~6°)
   | 'sensor'         // 光感应器 - 检测光强
   | 'mirror'         // 反射镜 - 反射光线
   | 'prism'          // 棱镜 - 折射并分散光线（色散效果）
   | 'lens'           // 透镜 - 聚焦或发散光线
   | 'beamSplitter'   // 分束器 - 50/50分光
-  | 'quarterWave'    // 四分之一波片 - 线偏振转圆偏振
-  | 'halfWave'       // 二分之一波片 - 翻转偏振方向
+  | 'quarterWave'    // ⚠️ 简化模型：45°旋转器 (非真正QWP，无圆偏振)
+  | 'halfWave'       // ⚠️ 简化模型：90°旋转器 (非真正HWP)
   | 'absorber'       // 吸收器 - 部分吸收光强
   | 'phaseShifter'   // 相位调制器 - 改变相位
   | 'portal';        // 传送门 - 传送光线到另一位置


### PR DESCRIPTION
Scientific accuracy audit addressing critical educational issues:

1. Quarter-Wave Plate (QWP) - Renamed to "Optical Rotator (45°)"
   - Old behavior (incorrect): QWP as polarization +45° rotation
   - Reality: QWP creates π/2 phase shift → circular polarization
   - Fix: Document as simplified rotator model, not true QWP

2. Calcite Splitter - Renamed to "Polarizing Beam Splitter (PBS)"
   - Old label (misleading): "Calcite" with 90° beam separation
   - Reality: Natural calcite has ~6° walk-off angle
   - Fix: Label as PBS/Wollaston Prism for 90° split accuracy

3. Interference Model - Added continuous phase support
   - Old model: Binary phase (±1) only
   - Added: calculateContinuousInterference() with formula: I = I₁ + I₂ + 2√(I₁I₂)cos(δ)
   - Documented binary limitation in legacy model

4. Visual Disclaimer - Added tooltip for false polarization colors
   - Explains colors represent polarization direction (0°,45°,90°,135°)
   - Not actual light wavelength

5. Documentation - Comprehensive scientific accuracy notes
   - LightPhysics.ts: Clear dual-model architecture explanation
   - types.ts: Block type simplification warnings
   - Points users to Jones Calculus for accurate simulations